### PR TITLE
Housekeeping

### DIFF
--- a/abstract_test.go
+++ b/abstract_test.go
@@ -153,7 +153,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 	if len(result.Errors) != 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -290,7 +290,7 @@ func TestAppendTypeUsedToAddRuntimeCustomScalarTypeForInterface(t *testing.T) {
 	if len(result.Errors) != 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -390,7 +390,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 	if len(result.Errors) != 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }

--- a/abstract_test.go
+++ b/abstract_test.go
@@ -48,7 +48,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Name, nil
 					}
@@ -57,7 +57,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 			},
 			"woofs": &graphql.Field{
 				Type: graphql.Boolean,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Woofs, nil
 					}
@@ -79,7 +79,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Name, nil
 					}
@@ -88,7 +88,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 			},
 			"meows": &graphql.Field{
 				Type: graphql.Boolean,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Meows, nil
 					}
@@ -103,8 +103,8 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 			Fields: graphql.Fields{
 				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-						return []interface{}{
+					Resolve: func(p graphql.ResolveParams) (any, error) {
+						return []any{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
 						}, nil
@@ -131,13 +131,13 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
     }`
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"pets": []interface{}{
-				map[string]interface{}{
+		Data: map[string]any{
+			"pets": []any{
+				map[string]any{
 					"name":  "Odie",
 					"woofs": bool(true),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"name":  "Garfield",
 					"meows": bool(false),
 				},
@@ -182,7 +182,7 @@ func TestAppendTypeUsedToAddRuntimeCustomScalarTypeForInterface(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Name, nil
 					}
@@ -191,7 +191,7 @@ func TestAppendTypeUsedToAddRuntimeCustomScalarTypeForInterface(t *testing.T) {
 			},
 			"woofs": &graphql.Field{
 				Type: graphql.Boolean,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Woofs, nil
 					}
@@ -213,7 +213,7 @@ func TestAppendTypeUsedToAddRuntimeCustomScalarTypeForInterface(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Name, nil
 					}
@@ -222,7 +222,7 @@ func TestAppendTypeUsedToAddRuntimeCustomScalarTypeForInterface(t *testing.T) {
 			},
 			"meows": &graphql.Field{
 				Type: graphql.Boolean,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Meows, nil
 					}
@@ -237,8 +237,8 @@ func TestAppendTypeUsedToAddRuntimeCustomScalarTypeForInterface(t *testing.T) {
 			Fields: graphql.Fields{
 				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-						return []interface{}{
+					Resolve: func(p graphql.ResolveParams) (any, error) {
+						return []any{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
 						}, nil
@@ -268,13 +268,13 @@ func TestAppendTypeUsedToAddRuntimeCustomScalarTypeForInterface(t *testing.T) {
 	    }`
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"pets": []interface{}{
-				map[string]interface{}{
+		Data: map[string]any{
+			"pets": []any{
+				map[string]any{
 					"name":  "Odie",
 					"woofs": bool(true),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"name":  "Garfield",
 					"meows": bool(false),
 				},
@@ -340,8 +340,8 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 			Fields: graphql.Fields{
 				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-						return []interface{}{
+					Resolve: func(p graphql.ResolveParams) (any, error) {
+						return []any{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
 						}, nil
@@ -368,13 +368,13 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
     }`
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"pets": []interface{}{
-				map[string]interface{}{
+		Data: map[string]any{
+			"pets": []any{
+				map[string]any{
 					"name":  "Odie",
 					"woofs": bool(true),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"name":  "Garfield",
 					"meows": bool(false),
 				},
@@ -463,8 +463,8 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 			Fields: graphql.Fields{
 				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-						return []interface{}{
+					Resolve: func(p graphql.ResolveParams) (any, error) {
+						return []any{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
 							&testHuman{"Jon"},
@@ -492,13 +492,13 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
     }`
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"pets": []interface{}{
-				map[string]interface{}{
+		Data: map[string]any{
+			"pets": []any{
+				map[string]any{
 					"name":  "Odie",
 					"woofs": bool(true),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"name":  "Garfield",
 					"meows": bool(false),
 				},
@@ -514,7 +514,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 						Column: 7,
 					},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"pets",
 					2,
 				},
@@ -587,8 +587,8 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 			Fields: graphql.Fields{
 				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-						return []interface{}{
+					Resolve: func(p graphql.ResolveParams) (any, error) {
+						return []any{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
 							&testHuman{"Jon"},
@@ -616,13 +616,13 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
     }`
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"pets": []interface{}{
-				map[string]interface{}{
+		Data: map[string]any{
+			"pets": []any{
+				map[string]any{
 					"name":  "Odie",
 					"woofs": bool(true),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"name":  "Garfield",
 					"meows": bool(false),
 				},
@@ -638,7 +638,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 						Column: 7,
 					},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"pets",
 					2,
 				},

--- a/benchutil/list_schema.go
+++ b/benchutil/list_schema.go
@@ -24,7 +24,7 @@ func ListSchemaWithXItems(x int) graphql.Schema {
 			"hex": &graphql.Field{
 				Type:        graphql.NewNonNull(graphql.String),
 				Description: "Hex color code.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if c, ok := p.Source.(color); ok {
 						return c.Hex, nil
 					}
@@ -34,7 +34,7 @@ func ListSchemaWithXItems(x int) graphql.Schema {
 			"r": &graphql.Field{
 				Type:        graphql.NewNonNull(graphql.Int),
 				Description: "Red value.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if c, ok := p.Source.(color); ok {
 						return c.R, nil
 					}
@@ -44,7 +44,7 @@ func ListSchemaWithXItems(x int) graphql.Schema {
 			"g": &graphql.Field{
 				Type:        graphql.NewNonNull(graphql.Int),
 				Description: "Green value.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if c, ok := p.Source.(color); ok {
 						return c.G, nil
 					}
@@ -54,7 +54,7 @@ func ListSchemaWithXItems(x int) graphql.Schema {
 			"b": &graphql.Field{
 				Type:        graphql.NewNonNull(graphql.Int),
 				Description: "Blue value.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if c, ok := p.Source.(color); ok {
 						return c.B, nil
 					}
@@ -69,7 +69,7 @@ func ListSchemaWithXItems(x int) graphql.Schema {
 		Fields: graphql.Fields{
 			"colors": {
 				Type: graphql.NewList(color),
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					return list, nil
 				},
 			},

--- a/benchutil/wide_schema.go
+++ b/benchutil/wide_schema.go
@@ -18,7 +18,7 @@ func WideSchemaWithXFieldsAndYItems(x int, y int) graphql.Schema {
 		Fields: graphql.Fields{
 			"wide": {
 				Type: graphql.NewList(wide),
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					out := make([]struct{}, 0, y)
 					for i := 0; i < y; i++ {
 						out = append(out, struct{}{})
@@ -89,41 +89,41 @@ func generateFieldNameFromX(x int) string {
 	return out
 }
 
-func generateWideResolveFromX(x int) func(p graphql.ResolveParams) (interface{}, error) {
+func generateWideResolveFromX(x int) func(p graphql.ResolveParams) (any, error) {
 	switch x % 8 {
 	case 0:
-		return func(p graphql.ResolveParams) (interface{}, error) {
+		return func(p graphql.ResolveParams) (any, error) {
 			return fmt.Sprint(x), nil
 		}
 	case 1:
-		return func(p graphql.ResolveParams) (interface{}, error) {
+		return func(p graphql.ResolveParams) (any, error) {
 			return fmt.Sprint(x), nil
 		}
 	case 2:
-		return func(p graphql.ResolveParams) (interface{}, error) {
+		return func(p graphql.ResolveParams) (any, error) {
 			return x, nil
 		}
 	case 3:
-		return func(p graphql.ResolveParams) (interface{}, error) {
+		return func(p graphql.ResolveParams) (any, error) {
 			return x, nil
 		}
 	case 4:
-		return func(p graphql.ResolveParams) (interface{}, error) {
+		return func(p graphql.ResolveParams) (any, error) {
 			return float64(x), nil
 		}
 	case 5:
-		return func(p graphql.ResolveParams) (interface{}, error) {
+		return func(p graphql.ResolveParams) (any, error) {
 			return float64(x), nil
 		}
 	case 6:
-		return func(p graphql.ResolveParams) (interface{}, error) {
+		return func(p graphql.ResolveParams) (any, error) {
 			if x%2 == 0 {
 				return false, nil
 			}
 			return true, nil
 		}
 	case 7:
-		return func(p graphql.ResolveParams) (interface{}, error) {
+		return func(p graphql.ResolveParams) (any, error) {
 			if x%2 == 0 {
 				return false, nil
 			}

--- a/definition.go
+++ b/definition.go
@@ -454,7 +454,7 @@ func (gt *Object) Interfaces() []*Interface {
 		configInterfaces = iface
 	case nil:
 	default:
-		gt.err = fmt.Errorf("Unknown Object.Interfaces type: %T", gt.typeConfig.Interfaces)
+		gt.err = fmt.Errorf("unknown Object.Interfaces type: %T", gt.typeConfig.Interfaces)
 		gt.initialisedInterfaces = true
 		return nil
 	}
@@ -796,7 +796,6 @@ type Union struct {
 	typeConfig      UnionConfig
 	initalizedTypes bool
 	types           []*Object
-	possibleTypes   map[string]bool
 
 	err error
 }
@@ -841,7 +840,7 @@ func (ut *Union) Types() []*Object {
 		unionTypes = utype
 	case nil:
 	default:
-		ut.err = fmt.Errorf("Unknown Union.Types type: %T", ut.typeConfig.Types)
+		ut.err = fmt.Errorf("unknown Union.Types type: %T", ut.typeConfig.Types)
 		ut.initalizedTypes = true
 		return nil
 	}

--- a/definition.go
+++ b/definition.go
@@ -67,7 +67,7 @@ type Leaf interface {
 	Description() string
 	String() string
 	Error() error
-	Serialize(value interface{}) interface{}
+	Serialize(value any) any
 }
 
 var _ Leaf = (*Scalar)(nil)
@@ -112,7 +112,7 @@ var _ Composite = (*Interface)(nil)
 var _ Composite = (*Union)(nil)
 
 // IsCompositeType determines if given type is a GraphQLComposite type
-func IsCompositeType(ttype interface{}) bool {
+func IsCompositeType(ttype any) bool {
 	switch ttype.(type) {
 	case *Object, *Interface, *Union:
 		return true
@@ -129,7 +129,7 @@ type Abstract interface {
 var _ Abstract = (*Interface)(nil)
 var _ Abstract = (*Union)(nil)
 
-func IsAbstractType(ttype interface{}) bool {
+func IsAbstractType(ttype any) bool {
 	switch ttype.(type) {
 	case *Interface, *Union:
 		return true
@@ -208,13 +208,13 @@ type Scalar struct {
 }
 
 // SerializeFn is a function type for serializing a GraphQLScalar type value
-type SerializeFn func(value interface{}) interface{}
+type SerializeFn func(value any) any
 
 // ParseValueFn is a function type for parsing the value of a GraphQLScalar type
-type ParseValueFn func(value interface{}) interface{}
+type ParseValueFn func(value any) any
 
 // ParseLiteralFn is a function type for parsing the literal value of a GraphQLScalar type
-type ParseLiteralFn func(valueAST ast.Value) interface{}
+type ParseLiteralFn func(valueAST ast.Value) any
 
 // ScalarConfig options for creating a new GraphQLScalar
 type ScalarConfig struct {
@@ -267,19 +267,19 @@ func NewScalar(config ScalarConfig) *Scalar {
 	st.scalarConfig = config
 	return st
 }
-func (st *Scalar) Serialize(value interface{}) interface{} {
+func (st *Scalar) Serialize(value any) any {
 	if st.scalarConfig.Serialize == nil {
 		return value
 	}
 	return st.scalarConfig.Serialize(value)
 }
-func (st *Scalar) ParseValue(value interface{}) interface{} {
+func (st *Scalar) ParseValue(value any) any {
 	if st.scalarConfig.ParseValue == nil {
 		return value
 	}
 	return st.scalarConfig.ParseValue(value)
 }
-func (st *Scalar) ParseLiteral(valueAST ast.Value) interface{} {
+func (st *Scalar) ParseLiteral(valueAST ast.Value) any {
 	if st.scalarConfig.ParseLiteral == nil {
 		return nil
 	}
@@ -352,7 +352,7 @@ type Object struct {
 type IsTypeOfParams struct {
 	// Value that needs to be resolve.
 	// Use this to decide which GraphQLObject this value maps to.
-	Value interface{}
+	Value any
 
 	// Info is a collection of information about the current execution state.
 	Info ResolveInfo
@@ -368,11 +368,11 @@ type IsTypeOfFn func(p IsTypeOfParams) bool
 type InterfacesThunk func() []*Interface
 
 type ObjectConfig struct {
-	Name        string      `json:"name"`
-	Interfaces  interface{} `json:"interfaces"`
-	Fields      interface{} `json:"fields"`
-	IsTypeOf    IsTypeOfFn  `json:"isTypeOf"`
-	Description string      `json:"description"`
+	Name        string     `json:"name"`
+	Interfaces  any        `json:"interfaces"`
+	Fields      any        `json:"fields"`
+	IsTypeOf    IsTypeOfFn `json:"isTypeOf"`
+	Description string     `json:"description"`
 }
 
 type FieldsThunk func() Fields
@@ -570,10 +570,10 @@ func defineFieldMap(ttype Named, fieldMap Fields) (FieldDefinitionMap, error) {
 // ResolveParams Params for FieldResolveFn()
 type ResolveParams struct {
 	// Source is the source value
-	Source interface{}
+	Source any
 
 	// Args is a map of arguments for current GraphQL request
-	Args map[string]interface{}
+	Args map[string]any
 
 	// Info is a collection of information about the current execution state.
 	Info ResolveInfo
@@ -584,7 +584,7 @@ type ResolveParams struct {
 	Context context.Context
 }
 
-type FieldResolveFn func(p ResolveParams) (interface{}, error)
+type FieldResolveFn func(p ResolveParams) (any, error)
 
 type ResolveInfo struct {
 	FieldName      string
@@ -594,9 +594,9 @@ type ResolveInfo struct {
 	ParentType     Composite
 	Schema         Schema
 	Fragments      map[string]ast.Definition
-	RootValue      interface{}
+	RootValue      any
 	Operation      ast.Definition
-	VariableValues map[string]interface{}
+	VariableValues map[string]any
 }
 
 type Fields map[string]*Field
@@ -614,9 +614,9 @@ type Field struct {
 type FieldConfigArgument map[string]*ArgumentConfig
 
 type ArgumentConfig struct {
-	Type         Input       `json:"type"`
-	DefaultValue interface{} `json:"defaultValue"`
-	Description  string      `json:"description"`
+	Type         Input  `json:"type"`
+	DefaultValue any    `json:"defaultValue"`
+	Description  string `json:"description"`
 }
 
 type FieldDefinitionMap map[string]*FieldDefinition
@@ -631,17 +631,17 @@ type FieldDefinition struct {
 }
 
 type FieldArgument struct {
-	Name         string      `json:"name"`
-	Type         Type        `json:"type"`
-	DefaultValue interface{} `json:"defaultValue"`
-	Description  string      `json:"description"`
+	Name         string `json:"name"`
+	Type         Type   `json:"type"`
+	DefaultValue any    `json:"defaultValue"`
+	Description  string `json:"description"`
 }
 
 type Argument struct {
-	PrivateName        string      `json:"name"`
-	Type               Input       `json:"type"`
-	DefaultValue       interface{} `json:"defaultValue"`
-	PrivateDescription string      `json:"description"`
+	PrivateName        string `json:"name"`
+	Type               Input  `json:"type"`
+	DefaultValue       any    `json:"defaultValue"`
+	PrivateDescription string `json:"description"`
 }
 
 func (st *Argument) Name() string {
@@ -684,8 +684,8 @@ type Interface struct {
 	err               error
 }
 type InterfaceConfig struct {
-	Name        string      `json:"name"`
-	Fields      interface{} `json:"fields"`
+	Name        string `json:"name"`
+	Fields      any    `json:"fields"`
 	ResolveType ResolveTypeFn
 	Description string `json:"description"`
 }
@@ -694,7 +694,7 @@ type InterfaceConfig struct {
 type ResolveTypeParams struct {
 	// Value that needs to be resolve.
 	// Use this to decide which GraphQLObject this value maps to.
-	Value interface{}
+	Value any
 
 	// Info is a collection of information about the current execution state.
 	Info ResolveInfo
@@ -804,8 +804,8 @@ type Union struct {
 type UnionTypesThunk func() []*Object
 
 type UnionConfig struct {
-	Name        string      `json:"name"`
-	Types       interface{} `json:"types"`
+	Name        string `json:"name"`
+	Types       any    `json:"types"`
 	ResolveType ResolveTypeFn
 	Description string `json:"description"`
 }
@@ -927,16 +927,16 @@ type Enum struct {
 
 	enumConfig   EnumConfig
 	values       []*EnumValueDefinition
-	valuesLookup map[interface{}]*EnumValueDefinition
+	valuesLookup map[any]*EnumValueDefinition
 	nameLookup   map[string]*EnumValueDefinition
 
 	err error
 }
 type EnumValueConfigMap map[string]*EnumValueConfig
 type EnumValueConfig struct {
-	Value             interface{} `json:"value"`
-	DeprecationReason string      `json:"deprecationReason"`
-	Description       string      `json:"description"`
+	Value             any    `json:"value"`
+	DeprecationReason string `json:"deprecationReason"`
+	Description       string `json:"description"`
 }
 type EnumConfig struct {
 	Name        string             `json:"name"`
@@ -944,10 +944,10 @@ type EnumConfig struct {
 	Description string             `json:"description"`
 }
 type EnumValueDefinition struct {
-	Name              string      `json:"name"`
-	Value             interface{} `json:"value"`
-	DeprecationReason string      `json:"deprecationReason"`
-	Description       string      `json:"description"`
+	Name              string `json:"name"`
+	Value             any    `json:"value"`
+	DeprecationReason string `json:"deprecationReason"`
+	Description       string `json:"description"`
 }
 
 func NewEnum(config EnumConfig) *Enum {
@@ -1004,7 +1004,7 @@ func (gt *Enum) defineEnumValues(valueMap EnumValueConfigMap) ([]*EnumValueDefin
 func (gt *Enum) Values() []*EnumValueDefinition {
 	return gt.values
 }
-func (gt *Enum) Serialize(value interface{}) interface{} {
+func (gt *Enum) Serialize(value any) any {
 	v := value
 	rv := reflect.ValueOf(v)
 	if kind := rv.Kind(); kind == reflect.Ptr && rv.IsNil() {
@@ -1017,7 +1017,7 @@ func (gt *Enum) Serialize(value interface{}) interface{} {
 	}
 	return nil
 }
-func (gt *Enum) ParseValue(value interface{}) interface{} {
+func (gt *Enum) ParseValue(value any) any {
 	var v string
 
 	switch value := value.(type) {
@@ -1033,7 +1033,7 @@ func (gt *Enum) ParseValue(value interface{}) interface{} {
 	}
 	return nil
 }
-func (gt *Enum) ParseLiteral(valueAST ast.Value) interface{} {
+func (gt *Enum) ParseLiteral(valueAST ast.Value) any {
 	if valueAST, ok := valueAST.(*ast.EnumValue); ok {
 		if enumValue, ok := gt.getNameLookup()[valueAST.Value]; ok {
 			return enumValue.Value
@@ -1053,11 +1053,11 @@ func (gt *Enum) String() string {
 func (gt *Enum) Error() error {
 	return gt.err
 }
-func (gt *Enum) getValueLookup() map[interface{}]*EnumValueDefinition {
+func (gt *Enum) getValueLookup() map[any]*EnumValueDefinition {
 	if len(gt.valuesLookup) > 0 {
 		return gt.valuesLookup
 	}
-	valuesLookup := map[interface{}]*EnumValueDefinition{}
+	valuesLookup := map[any]*EnumValueDefinition{}
 	for _, value := range gt.Values() {
 		valuesLookup[value.Value] = value
 	}
@@ -1104,15 +1104,15 @@ type InputObject struct {
 	err        error
 }
 type InputObjectFieldConfig struct {
-	Type         Input       `json:"type"`
-	DefaultValue interface{} `json:"defaultValue"`
-	Description  string      `json:"description"`
+	Type         Input  `json:"type"`
+	DefaultValue any    `json:"defaultValue"`
+	Description  string `json:"description"`
 }
 type InputObjectField struct {
-	PrivateName        string      `json:"name"`
-	Type               Input       `json:"type"`
-	DefaultValue       interface{} `json:"defaultValue"`
-	PrivateDescription string      `json:"description"`
+	PrivateName        string `json:"name"`
+	Type               Input  `json:"type"`
+	DefaultValue       any    `json:"defaultValue"`
+	PrivateDescription string `json:"description"`
 }
 
 func (st *InputObjectField) Name() string {
@@ -1132,9 +1132,9 @@ type InputObjectConfigFieldMap map[string]*InputObjectFieldConfig
 type InputObjectFieldMap map[string]*InputObjectField
 type InputObjectConfigFieldMapThunk func() InputObjectConfigFieldMap
 type InputObjectConfig struct {
-	Name        string      `json:"name"`
-	Fields      interface{} `json:"fields"`
-	Description string      `json:"description"`
+	Name        string `json:"name"`
+	Fields      any    `json:"fields"`
+	Description string `json:"description"`
 }
 
 func NewInputObject(config InputObjectConfig) *InputObject {
@@ -1334,11 +1334,11 @@ func assertValidName(name string) error {
 
 type ResponsePath struct {
 	Prev *ResponsePath
-	Key  interface{}
+	Key  any
 }
 
 // WithKey returns a new responsePath containing the new key.
-func (p *ResponsePath) WithKey(key interface{}) *ResponsePath {
+func (p *ResponsePath) WithKey(key any) *ResponsePath {
 	return &ResponsePath{
 		Prev: p,
 		Key:  key,
@@ -1346,7 +1346,7 @@ func (p *ResponsePath) WithKey(key interface{}) *ResponsePath {
 }
 
 // AsArray returns an array of path keys.
-func (p *ResponsePath) AsArray() []interface{} {
+func (p *ResponsePath) AsArray() []any {
 	if p == nil {
 		return nil
 	}

--- a/definition_test.go
+++ b/definition_test.go
@@ -155,7 +155,7 @@ func TestTypeSystem_DefinitionExample_DefinesAQueryOnlySchema(t *testing.T) {
 		t.Fatalf("expected blogSchema.GetQueryType() == blogQuery")
 	}
 
-	articleField, _ := blogQuery.Fields()["article"]
+	articleField := blogQuery.Fields()["article"]
 	if articleField == nil {
 		t.Fatalf("articleField is nil")
 	}
@@ -232,7 +232,7 @@ func TestTypeSystem_DefinitionExample_DefinesAMutationScheme(t *testing.T) {
 		t.Fatalf("expected blogSchema.GetMutationType() == blogMutation")
 	}
 
-	writeMutation, _ := blogMutation.Fields()["writeArticle"]
+	writeMutation := blogMutation.Fields()["writeArticle"]
 	if writeMutation == nil {
 		t.Fatalf("writeMutation is nil")
 	}
@@ -261,7 +261,7 @@ func TestTypeSystem_DefinitionExample_DefinesASubscriptionScheme(t *testing.T) {
 		t.Fatalf("expected blogSchema.SubscriptionType() == blogSubscription")
 	}
 
-	subMutation, _ := blogSubscription.Fields()["articleSubscribe"]
+	subMutation := blogSubscription.Fields()["articleSubscribe"]
 	if subMutation == nil {
 		t.Fatalf("subMutation is nil")
 	}

--- a/definition_test.go
+++ b/definition_test.go
@@ -719,7 +719,7 @@ func TestTypeSystem_DefinitionExample_HandlesInvalidUnionTypes(t *testing.T) {
 	})
 
 	unionTypes := someUnion.Types()
-	expected := "Unknown Union.Types type: graphql.InterfacesThunk"
+	expected := "unknown Union.Types type: graphql.InterfacesThunk"
 
 	if someUnion.Error().Error() != expected {
 		t.Fatalf("Unexpected error, got: %v, want: %v", someUnion.Error().Error(), expected)

--- a/directives_test.go
+++ b/directives_test.go
@@ -23,9 +23,9 @@ var directivesTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 	}),
 })
 
-var directivesTestData map[string]interface{} = map[string]interface{}{
-	"a": func() interface{} { return "a" },
-	"b": func() interface{} { return "b" },
+var directivesTestData map[string]any = map[string]any{
+	"a": func() any { return "a" },
+	"b": func() any { return "b" },
 }
 
 func executeDirectivesTestQuery(t *testing.T, doc string) *graphql.Result {
@@ -147,7 +147,7 @@ func TestDirectives_DirectiveArgNamesMustBeValid(t *testing.T) {
 func TestDirectivesWorksWithoutDirectives(t *testing.T) {
 	query := `{ a, b }`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 			"b": "b",
 		},
@@ -161,7 +161,7 @@ func TestDirectivesWorksWithoutDirectives(t *testing.T) {
 func TestDirectivesWorksOnScalarsIfTrueIncludesScalar(t *testing.T) {
 	query := `{ a, b @include(if: true) }`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 			"b": "b",
 		},
@@ -175,7 +175,7 @@ func TestDirectivesWorksOnScalarsIfTrueIncludesScalar(t *testing.T) {
 func TestDirectivesWorksOnScalarsIfFalseOmitsOnScalar(t *testing.T) {
 	query := `{ a, b @include(if: false) }`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 		},
 	}
@@ -188,7 +188,7 @@ func TestDirectivesWorksOnScalarsIfFalseOmitsOnScalar(t *testing.T) {
 func TestDirectivesWorksOnScalarsUnlessFalseIncludesScalar(t *testing.T) {
 	query := `{ a, b @skip(if: false) }`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 			"b": "b",
 		},
@@ -202,7 +202,7 @@ func TestDirectivesWorksOnScalarsUnlessFalseIncludesScalar(t *testing.T) {
 func TestDirectivesWorksOnScalarsUnlessTrueOmitsScalar(t *testing.T) {
 	query := `{ a, b @skip(if: true) }`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 		},
 	}
@@ -223,7 +223,7 @@ func TestDirectivesWorksOnFragmentSpreadsIfFalseOmitsFragmentSpread(t *testing.T
         }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 		},
 	}
@@ -244,7 +244,7 @@ func TestDirectivesWorksOnFragmentSpreadsIfTrueIncludesFragmentSpread(t *testing
         }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 			"b": "b",
 		},
@@ -266,7 +266,7 @@ func TestDirectivesWorksOnFragmentSpreadsUnlessFalseIncludesFragmentSpread(t *te
         }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 			"b": "b",
 		},
@@ -288,7 +288,7 @@ func TestDirectivesWorksOnFragmentSpreadsUnlessTrueOmitsFragmentSpread(t *testin
         }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 		},
 	}
@@ -308,7 +308,7 @@ func TestDirectivesWorksOnInlineFragmentIfFalseOmitsInlineFragment(t *testing.T)
         }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 		},
 	}
@@ -328,7 +328,7 @@ func TestDirectivesWorksOnInlineFragmentIfTrueIncludesInlineFragment(t *testing.
         }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 			"b": "b",
 		},
@@ -349,7 +349,7 @@ func TestDirectivesWorksOnInlineFragmentUnlessFalseIncludesInlineFragment(t *tes
         }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 			"b": "b",
 		},
@@ -370,7 +370,7 @@ func TestDirectivesWorksOnInlineFragmentUnlessTrueIncludesInlineFragment(t *test
         }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 		},
 	}
@@ -390,7 +390,7 @@ func TestDirectivesWorksOnAnonymousInlineFragmentIfFalseOmitsAnonymousInlineFrag
         }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 		},
 	}
@@ -410,7 +410,7 @@ func TestDirectivesWorksOnAnonymousInlineFragmentIfTrueIncludesAnonymousInlineFr
         }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 			"b": "b",
 		},
@@ -431,7 +431,7 @@ func TestDirectivesWorksOnAnonymousInlineFragmentUnlessFalseIncludesAnonymousInl
         }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 			"b": "b",
 		},
@@ -452,7 +452,7 @@ func TestDirectivesWorksOnAnonymousInlineFragmentUnlessTrueIncludesAnonymousInli
         }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 		},
 	}
@@ -465,7 +465,7 @@ func TestDirectivesWorksOnAnonymousInlineFragmentUnlessTrueIncludesAnonymousInli
 func TestDirectivesWorksWithSkipAndIncludeDirectives_IncludeAndNoSkip(t *testing.T) {
 	query := `{ a, b @include(if: true) @skip(if: false) }`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 			"b": "b",
 		},
@@ -479,7 +479,7 @@ func TestDirectivesWorksWithSkipAndIncludeDirectives_IncludeAndNoSkip(t *testing
 func TestDirectivesWorksWithSkipAndIncludeDirectives_IncludeAndSkip(t *testing.T) {
 	query := `{ a, b @include(if: true) @skip(if: true) }`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 		},
 	}
@@ -492,7 +492,7 @@ func TestDirectivesWorksWithSkipAndIncludeDirectives_IncludeAndSkip(t *testing.T
 func TestDirectivesWorksWithSkipAndIncludeDirectives_NoIncludeAndSkip(t *testing.T) {
 	query := `{ a, b @include(if: false) @skip(if: true) }`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 		},
 	}
@@ -505,7 +505,7 @@ func TestDirectivesWorksWithSkipAndIncludeDirectives_NoIncludeAndSkip(t *testing
 func TestDirectivesWorksWithSkipAndIncludeDirectives_NoIncludeOrSkip(t *testing.T) {
 	query := `{ a, b @include(if: false) @skip(if: false) }`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 		},
 	}

--- a/enum_type_test.go
+++ b/enum_type_test.go
@@ -144,7 +144,7 @@ func TestTypeSystem_EnumValues_AcceptsEnumLiteralsAsInput(t *testing.T) {
 		},
 	}
 	result := executeEnumTypeTest(t, query)
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -157,7 +157,7 @@ func TestTypeSystem_EnumValues_EnumMayBeOutputType(t *testing.T) {
 		},
 	}
 	result := executeEnumTypeTest(t, query)
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -169,7 +169,7 @@ func TestTypeSystem_EnumValues_EnumMayBeBothInputAndOutputType(t *testing.T) {
 		},
 	}
 	result := executeEnumTypeTest(t, query)
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -199,7 +199,7 @@ func TestTypeSystem_EnumValues_DoesNotAcceptIncorrectInternalValue(t *testing.T)
 		},
 	}
 	result := executeEnumTypeTest(t, query)
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -252,7 +252,7 @@ func TestTypeSystem_EnumValues_AcceptsJSONStringAsEnumVariable(t *testing.T) {
 		},
 	}
 	result := executeEnumTypeTestWithParams(t, query, params)
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -268,7 +268,7 @@ func TestTypeSystem_EnumValues_AcceptsEnumLiteralsAsInputArgumentsToMutations(t 
 		},
 	}
 	result := executeEnumTypeTestWithParams(t, query, params)
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -284,7 +284,7 @@ func TestTypeSystem_EnumValues_AcceptsEnumLiteralsAsInputArgumentsToSubscription
 		},
 	}
 	result := executeEnumTypeTestWithParams(t, query, params)
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -357,7 +357,7 @@ func TestTypeSystem_EnumValues_EnumValueMayHaveAnInternalValueOfZero(t *testing.
 		},
 	}
 	result := executeEnumTypeTest(t, query)
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -373,7 +373,7 @@ func TestTypeSystem_EnumValues_EnumValueMayBeNullable(t *testing.T) {
 		},
 	}
 	result := executeEnumTypeTest(t, query)
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -417,7 +417,7 @@ func TestTypeSystem_EnumValues_EnumValueMayBePointer(t *testing.T) {
 		Schema:        enumTypeTestSchema,
 		RequestString: query,
 	})
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -456,7 +456,7 @@ func TestTypeSystem_EnumValues_EnumValueMayBeNilPointer(t *testing.T) {
 		Schema:        enumTypeTestSchema,
 		RequestString: query,
 	})
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }

--- a/enum_type_test.go
+++ b/enum_type_test.go
@@ -40,7 +40,7 @@ var enumTypeTestQueryType = graphql.NewObject(graphql.ObjectConfig{
 					Type: graphql.String,
 				},
 			},
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(p graphql.ResolveParams) (any, error) {
 				if fromInt, ok := p.Args["fromInt"]; ok {
 					return fromInt, nil
 				}
@@ -63,7 +63,7 @@ var enumTypeTestQueryType = graphql.NewObject(graphql.ObjectConfig{
 					Type: graphql.Int,
 				},
 			},
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(p graphql.ResolveParams) (any, error) {
 				if fromInt, ok := p.Args["fromInt"]; ok {
 					return fromInt, nil
 				}
@@ -85,7 +85,7 @@ var enumTypeTestMutationType = graphql.NewObject(graphql.ObjectConfig{
 					Type: enumTypeTestColorType,
 				},
 			},
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(p graphql.ResolveParams) (any, error) {
 				if color, ok := p.Args["color"]; ok {
 					return color, nil
 				}
@@ -105,7 +105,7 @@ var enumTypeTestSubscriptionType = graphql.NewObject(graphql.ObjectConfig{
 					Type: enumTypeTestColorType,
 				},
 			},
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(p graphql.ResolveParams) (any, error) {
 				if color, ok := p.Args["color"]; ok {
 					return color, nil
 				}
@@ -128,7 +128,7 @@ func executeEnumTypeTest(t *testing.T, query string) *graphql.Result {
 	})
 	return result
 }
-func executeEnumTypeTestWithParams(t *testing.T, query string, params map[string]interface{}) *graphql.Result {
+func executeEnumTypeTestWithParams(t *testing.T, query string, params map[string]any) *graphql.Result {
 	result := g(t, graphql.Params{
 		Schema:         enumTypeTestSchema,
 		RequestString:  query,
@@ -139,7 +139,7 @@ func executeEnumTypeTestWithParams(t *testing.T, query string, params map[string
 func TestTypeSystem_EnumValues_AcceptsEnumLiteralsAsInput(t *testing.T) {
 	query := "{ colorInt(fromEnum: GREEN) }"
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"colorInt": 1,
 		},
 	}
@@ -152,7 +152,7 @@ func TestTypeSystem_EnumValues_AcceptsEnumLiteralsAsInput(t *testing.T) {
 func TestTypeSystem_EnumValues_EnumMayBeOutputType(t *testing.T) {
 	query := "{ colorEnum(fromInt: 1) }"
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"colorEnum": "GREEN",
 		},
 	}
@@ -164,7 +164,7 @@ func TestTypeSystem_EnumValues_EnumMayBeOutputType(t *testing.T) {
 func TestTypeSystem_EnumValues_EnumMayBeBothInputAndOutputType(t *testing.T) {
 	query := "{ colorEnum(fromEnum: GREEN) }"
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"colorEnum": "GREEN",
 		},
 	}
@@ -194,7 +194,7 @@ func TestTypeSystem_EnumValues_DoesNotAcceptStringLiterals(t *testing.T) {
 func TestTypeSystem_EnumValues_DoesNotAcceptIncorrectInternalValue(t *testing.T) {
 	query := `{ colorEnum(fromString: "GREEN") }`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"colorEnum": nil,
 		},
 	}
@@ -243,11 +243,11 @@ func TestTypeSystem_EnumValues_DoesNotAcceptEnumLiteralInPlaceOfInt(t *testing.T
 
 func TestTypeSystem_EnumValues_AcceptsJSONStringAsEnumVariable(t *testing.T) {
 	query := `query test($color: Color!) { colorEnum(fromEnum: $color) }`
-	params := map[string]interface{}{
+	params := map[string]any{
 		"color": "BLUE",
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"colorEnum": "BLUE",
 		},
 	}
@@ -259,11 +259,11 @@ func TestTypeSystem_EnumValues_AcceptsJSONStringAsEnumVariable(t *testing.T) {
 
 func TestTypeSystem_EnumValues_AcceptsEnumLiteralsAsInputArgumentsToMutations(t *testing.T) {
 	query := `mutation x($color: Color!) { favoriteEnum(color: $color) }`
-	params := map[string]interface{}{
+	params := map[string]any{
 		"color": "GREEN",
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"favoriteEnum": "GREEN",
 		},
 	}
@@ -275,11 +275,11 @@ func TestTypeSystem_EnumValues_AcceptsEnumLiteralsAsInputArgumentsToMutations(t 
 
 func TestTypeSystem_EnumValues_AcceptsEnumLiteralsAsInputArgumentsToSubscriptions(t *testing.T) {
 	query := `subscription x($color: Color!) { subscribeToEnum(color: $color) }`
-	params := map[string]interface{}{
+	params := map[string]any{
 		"color": "GREEN",
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"subscribeToEnum": "GREEN",
 		},
 	}
@@ -290,7 +290,7 @@ func TestTypeSystem_EnumValues_AcceptsEnumLiteralsAsInputArgumentsToSubscription
 }
 func TestTypeSystem_EnumValues_DoesNotAcceptInternalValueAsEnumVariable(t *testing.T) {
 	query := `query test($color: Color!) { colorEnum(fromEnum: $color) }`
-	params := map[string]interface{}{
+	params := map[string]any{
 		"color": 2,
 	}
 	expected := &graphql.Result{
@@ -311,7 +311,7 @@ func TestTypeSystem_EnumValues_DoesNotAcceptInternalValueAsEnumVariable(t *testi
 }
 func TestTypeSystem_EnumValues_DoesNotAcceptStringVariablesAsEnumInput(t *testing.T) {
 	query := `query test($color: String!) { colorEnum(fromEnum: $color) }`
-	params := map[string]interface{}{
+	params := map[string]any{
 		"color": "BLUE",
 	}
 	expected := &graphql.Result{
@@ -329,7 +329,7 @@ func TestTypeSystem_EnumValues_DoesNotAcceptStringVariablesAsEnumInput(t *testin
 }
 func TestTypeSystem_EnumValues_DoesNotAcceptInternalValueVariableAsEnumInput(t *testing.T) {
 	query := `query test($color: Int!) { colorEnum(fromEnum: $color) }`
-	params := map[string]interface{}{
+	params := map[string]any{
 		"color": 2,
 	}
 	expected := &graphql.Result{
@@ -351,7 +351,7 @@ func TestTypeSystem_EnumValues_EnumValueMayHaveAnInternalValueOfZero(t *testing.
         colorInt(fromEnum: RED)
       }`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"colorEnum": "RED",
 			"colorInt":  0,
 		},
@@ -367,7 +367,7 @@ func TestTypeSystem_EnumValues_EnumValueMayBeNullable(t *testing.T) {
         colorInt
       }`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"colorEnum": nil,
 			"colorInt":  nil,
 		},
@@ -396,7 +396,7 @@ func TestTypeSystem_EnumValues_EnumValueMayBePointer(t *testing.T) {
 							},
 						},
 					}),
-					Resolve: func(_ graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(_ graphql.ResolveParams) (any, error) {
 						one := 1
 						return struct {
 							Color *int `graphql:"color"`
@@ -409,8 +409,8 @@ func TestTypeSystem_EnumValues_EnumValueMayBePointer(t *testing.T) {
 	})
 	query := "{ query { color foo } }"
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"query": map[string]interface{}{
+		Data: map[string]any{
+			"query": map[string]any{
 				"color": "GREEN",
 				"foo":   1}}}
 	result := g(t, graphql.Params{
@@ -436,7 +436,7 @@ func TestTypeSystem_EnumValues_EnumValueMayBeNilPointer(t *testing.T) {
 							},
 						},
 					}),
-					Resolve: func(_ graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(_ graphql.ResolveParams) (any, error) {
 						return struct {
 							Color *int `graphql:"color"`
 						}{nil}, nil
@@ -447,8 +447,8 @@ func TestTypeSystem_EnumValues_EnumValueMayBeNilPointer(t *testing.T) {
 	})
 	query := "{ query { color } }"
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"query": map[string]interface{}{
+		Data: map[string]any{
+			"query": map[string]any{
 				"color": nil,
 			}},
 	}

--- a/examples/concurrent-resolvers/main.go
+++ b/examples/concurrent-resolvers/main.go
@@ -38,18 +38,18 @@ var QueryType = graphql.NewObject(graphql.ObjectConfig{
 	Fields: graphql.Fields{
 		"concurrentFieldFoo": &graphql.Field{
 			Type: FieldFooType,
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(p graphql.ResolveParams) (any, error) {
 				var foo = Foo{Name: "Foo's name"}
-				return func() (interface{}, error) {
+				return func() (any, error) {
 					return &foo, nil
 				}, nil
 			},
 		},
 		"concurrentFieldBar": &graphql.Field{
 			Type: FieldBarType,
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(p graphql.ResolveParams) (any, error) {
 				type result struct {
-					data interface{}
+					data any
 					err  error
 				}
 				ch := make(chan *result, 1)
@@ -58,7 +58,7 @@ var QueryType = graphql.NewObject(graphql.ObjectConfig{
 					bar := &Bar{Name: "Bar's name"}
 					ch <- &result{data: bar, err: nil}
 				}()
-				return func() (interface{}, error) {
+				return func() (any, error) {
 					r := <-ch
 					return r.data, r.err
 				}, nil

--- a/examples/context/main.go
+++ b/examples/context/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/machship/graphql"
+	"github.com/machship/graphql/testutil"
 )
 
 var Schema graphql.Schema
@@ -33,7 +34,7 @@ var queryType = graphql.NewObject(
 			"me": &graphql.Field{
 				Type: userType,
 				Resolve: func(p graphql.ResolveParams) (any, error) {
-					return p.Context.Value("currentUser"), nil
+					return testutil.ContextValue(p.Context, "currentUser"), nil
 				},
 			},
 		},
@@ -47,7 +48,7 @@ func graphqlHandler(w http.ResponseWriter, r *http.Request) {
 	result := graphql.Do(graphql.Params{
 		Schema:        Schema,
 		RequestString: r.URL.Query().Get("query"),
-		Context:       context.WithValue(context.Background(), "currentUser", user),
+		Context:       testutil.ContextWithValue(context.Background(), "currentUser", user),
 	})
 	if len(result.Errors) > 0 {
 		log.Printf("wrong result, unexpected errors: %v", result.Errors)

--- a/examples/context/main.go
+++ b/examples/context/main.go
@@ -32,7 +32,7 @@ var queryType = graphql.NewObject(
 		Fields: graphql.Fields{
 			"me": &graphql.Field{
 				Type: userType,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					return p.Context.Value("currentUser"), nil
 				},
 			},

--- a/examples/crud/main.go
+++ b/examples/crud/main.go
@@ -74,7 +74,7 @@ var queryType = graphql.NewObject(
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					id, ok := p.Args["id"].(int)
 					if ok {
 						// Find product
@@ -93,7 +93,7 @@ var queryType = graphql.NewObject(
 			"list": &graphql.Field{
 				Type:        graphql.NewList(productType),
 				Description: "Get product list",
-				Resolve: func(params graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(params graphql.ResolveParams) (any, error) {
 					return products, nil
 				},
 			},
@@ -120,7 +120,7 @@ var mutationType = graphql.NewObject(graphql.ObjectConfig{
 					Type: graphql.NewNonNull(graphql.Float),
 				},
 			},
-			Resolve: func(params graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(params graphql.ResolveParams) (any, error) {
 				rand.Seed(time.Now().UnixNano())
 				product := Product{
 					ID:    int64(rand.Intn(100000)), // generate random ID
@@ -153,7 +153,7 @@ var mutationType = graphql.NewObject(graphql.ObjectConfig{
 					Type: graphql.Float,
 				},
 			},
-			Resolve: func(params graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(params graphql.ResolveParams) (any, error) {
 				id, _ := params.Args["id"].(int)
 				name, nameOk := params.Args["name"].(string)
 				info, infoOk := params.Args["info"].(string)
@@ -189,7 +189,7 @@ var mutationType = graphql.NewObject(graphql.ObjectConfig{
 					Type: graphql.NewNonNull(graphql.Int),
 				},
 			},
-			Resolve: func(params graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(params graphql.ResolveParams) (any, error) {
 				id, _ := params.Args["id"].(int)
 				product := Product{}
 				for i, p := range products {

--- a/examples/crud/main.go
+++ b/examples/crud/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
-	"time"
 
 	"github.com/machship/graphql"
 )
@@ -121,7 +120,6 @@ var mutationType = graphql.NewObject(graphql.ObjectConfig{
 				},
 			},
 			Resolve: func(params graphql.ResolveParams) (any, error) {
-				rand.Seed(time.Now().UnixNano())
 				product := Product{
 					ID:    int64(rand.Intn(100000)), // generate random ID
 					Name:  params.Args["name"].(string),

--- a/examples/custom-scalar-type/main.go
+++ b/examples/custom-scalar-type/main.go
@@ -25,7 +25,7 @@ var CustomScalarType = graphql.NewScalar(graphql.ScalarConfig{
 	Name:        "CustomScalarType",
 	Description: "The `CustomScalarType` scalar type represents an ID Object.",
 	// Serialize serializes `CustomID` to string.
-	Serialize: func(value interface{}) interface{} {
+	Serialize: func(value any) any {
 		switch value := value.(type) {
 		case CustomID:
 			return value.String()
@@ -37,7 +37,7 @@ var CustomScalarType = graphql.NewScalar(graphql.ScalarConfig{
 		}
 	},
 	// ParseValue parses GraphQL variables from `string` to `CustomID`.
-	ParseValue: func(value interface{}) interface{} {
+	ParseValue: func(value any) any {
 		switch value := value.(type) {
 		case string:
 			return NewCustomID(value)
@@ -48,7 +48,7 @@ var CustomScalarType = graphql.NewScalar(graphql.ScalarConfig{
 		}
 	},
 	// ParseLiteral parses GraphQL AST value to `CustomID`.
-	ParseLiteral: func(valueAST ast.Value) interface{} {
+	ParseLiteral: func(valueAST ast.Value) any {
 		switch valueAST := valueAST.(type) {
 		case *ast.StringValue:
 			return NewCustomID(valueAST.Value)
@@ -83,7 +83,7 @@ func main() {
 							Type: CustomScalarType,
 						},
 					},
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(p graphql.ResolveParams) (any, error) {
 						// id := p.Args["id"]
 						// log.Printf("id from arguments: %+v", id)
 						customers := []Customer{
@@ -126,7 +126,7 @@ func main() {
 	result := graphql.Do(graphql.Params{
 		Schema:        schema,
 		RequestString: query,
-		VariableValues: map[string]interface{}{
+		VariableValues: map[string]any{
 			"id": "5b42ba57289",
 		},
 	})

--- a/examples/custom-scalar-type/main.go
+++ b/examples/custom-scalar-type/main.go
@@ -87,7 +87,7 @@ func main() {
 						// id := p.Args["id"]
 						// log.Printf("id from arguments: %+v", id)
 						customers := []Customer{
-							Customer{ID: NewCustomID("fb278f2a4a13f")},
+							{ID: NewCustomID("fb278f2a4a13f")},
 						}
 						return customers, nil
 					},

--- a/examples/hello-world/main.go
+++ b/examples/hello-world/main.go
@@ -13,7 +13,7 @@ func main() {
 	fields := graphql.Fields{
 		"hello": &graphql.Field{
 			Type: graphql.String,
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(p graphql.ResolveParams) (any, error) {
 				return "world", nil
 			},
 		},

--- a/examples/http-post/main.go
+++ b/examples/http-post/main.go
@@ -10,9 +10,9 @@ import (
 )
 
 type postData struct {
-	Query     string                 `json:"query"`
-	Operation string                 `json:"operationName"`
-	Variables map[string]interface{} `json:"variables"`
+	Query     string         `json:"query"`
+	Operation string         `json:"operationName"`
+	Variables map[string]any `json:"variables"`
 }
 
 func main() {

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -17,10 +17,11 @@ type user struct {
 var data map[string]user
 
 /*
-   Create User object type with fields "id" and "name" by using GraphQLObjectTypeConfig:
-       - Name: name of object type
-       - Fields: a map of fields by using GraphQLFields
-   Setup type of field use GraphQLFieldConfig
+Create User object type with fields "id" and "name" by using GraphQLObjectTypeConfig:
+  - Name: name of object type
+  - Fields: a map of fields by using GraphQLFields
+
+Setup type of field use GraphQLFieldConfig
 */
 var userType = graphql.NewObject(
 	graphql.ObjectConfig{
@@ -37,13 +38,14 @@ var userType = graphql.NewObject(
 )
 
 /*
-   Create Query object type with fields "user" has type [userType] by using GraphQLObjectTypeConfig:
-       - Name: name of object type
-       - Fields: a map of fields by using GraphQLFields
-   Setup type of field use GraphQLFieldConfig to define:
-       - Type: type of field
-       - Args: arguments to query with current field
-       - Resolve: function to query data using params from [Args] and return value with current type
+Create Query object type with fields "user" has type [userType] by using GraphQLObjectTypeConfig:
+  - Name: name of object type
+  - Fields: a map of fields by using GraphQLFields
+
+Setup type of field use GraphQLFieldConfig to define:
+  - Type: type of field
+  - Args: arguments to query with current field
+  - Resolve: function to query data using params from [Args] and return value with current type
 */
 var queryType = graphql.NewObject(
 	graphql.ObjectConfig{
@@ -56,7 +58,7 @@ var queryType = graphql.NewObject(
 						Type: graphql.String,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					idQuery, isOK := p.Args["id"].(string)
 					if isOK {
 						return data[idQuery], nil
@@ -97,8 +99,8 @@ func main() {
 	http.ListenAndServe(":8080", nil)
 }
 
-//Helper function to import json from file to map
-func importJSONDataFromFile(fileName string, result interface{}) (isOK bool) {
+// Helper function to import json from file to map
+func importJSONDataFromFile(fileName string, result any) (isOK bool) {
 	isOK = true
 	content, err := ioutil.ReadFile(fileName)
 	if err != nil {

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/machship/graphql"
 )
@@ -102,7 +102,7 @@ func main() {
 // Helper function to import json from file to map
 func importJSONDataFromFile(fileName string, result any) (isOK bool) {
 	isOK = true
-	content, err := ioutil.ReadFile(fileName)
+	content, err := os.ReadFile(fileName)
 	if err != nil {
 		fmt.Print("Error:", err)
 		isOK = false

--- a/examples/httpdynamic/main.go
+++ b/examples/httpdynamic/main.go
@@ -33,7 +33,7 @@ func handleSIGUSR1(c chan os.Signal) {
 	}
 }
 
-func filterUser(data []map[string]interface{}, args map[string]interface{}) map[string]interface{} {
+func filterUser(data []map[string]any, args map[string]any) map[string]any {
 	for _, user := range data {
 		for k, v := range args {
 			if user[k] != v {
@@ -64,7 +64,7 @@ func importJSONDataFromFile(fileName string) error {
 		return err
 	}
 
-	var data []map[string]interface{}
+	var data []map[string]any
 
 	err = json.Unmarshal(content, &data)
 	if err != nil {
@@ -98,7 +98,7 @@ func importJSONDataFromFile(fileName string) error {
 				"user": &graphql.Field{
 					Type: userType,
 					Args: args,
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(p graphql.ResolveParams) (any, error) {
 						return filterUser(data, p.Args), nil
 					},
 				},

--- a/examples/httpdynamic/main.go
+++ b/examples/httpdynamic/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/signal"
@@ -59,7 +58,7 @@ func executeQuery(query string, schema graphql.Schema) *graphql.Result {
 }
 
 func importJSONDataFromFile(fileName string) error {
-	content, err := ioutil.ReadFile(fileName)
+	content, err := os.ReadFile(fileName)
 	if err != nil {
 		return err
 	}

--- a/examples/modify-context/main.go
+++ b/examples/modify-context/main.go
@@ -18,8 +18,8 @@ var UserType = graphql.NewObject(graphql.ObjectConfig{
 	Fields: graphql.Fields{
 		"id": &graphql.Field{
 			Type: graphql.Int,
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-				rootValue := p.Info.RootValue.(map[string]interface{})
+			Resolve: func(p graphql.ResolveParams) (any, error) {
+				rootValue := p.Info.RootValue.(map[string]any)
 				if rootValue["data-from-parent"] == "ok" &&
 					rootValue["data-before-execution"] == "ok" {
 					user := p.Source.(User)
@@ -38,8 +38,8 @@ func main() {
 			Fields: graphql.Fields{
 				"users": &graphql.Field{
 					Type: graphql.NewList(UserType),
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-						rootValue := p.Info.RootValue.(map[string]interface{})
+					Resolve: func(p graphql.ResolveParams) (any, error) {
+						rootValue := p.Info.RootValue.(map[string]any)
 						rootValue["data-from-parent"] = "ok"
 						result := []User{
 							User{ID: 1},
@@ -58,7 +58,7 @@ func main() {
 	// Instead of trying to modify context within a resolve function, use:
 	// `graphql.Params.RootObject` is a mutable optional variable and available on
 	// each resolve function via: `graphql.ResolveParams.Info.RootValue`.
-	rootObject := map[string]interface{}{
+	rootObject := map[string]any{
 		"data-before-execution": "ok",
 	}
 	result := graphql.Do(graphql.Params{

--- a/examples/modify-context/main.go
+++ b/examples/modify-context/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 
 	"github.com/machship/graphql"
+	"github.com/machship/graphql/testutil"
 )
 
 type User struct {
@@ -42,7 +43,7 @@ func main() {
 						rootValue := p.Info.RootValue.(map[string]any)
 						rootValue["data-from-parent"] = "ok"
 						result := []User{
-							User{ID: 1},
+							{ID: 1},
 						}
 						return result, nil
 
@@ -54,7 +55,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	ctx := context.WithValue(context.Background(), "currentUser", User{ID: 100})
+	ctx := testutil.ContextWithValue(context.Background(), "currentUser", User{ID: 100})
 	// Instead of trying to modify context within a resolve function, use:
 	// `graphql.Params.RootObject` is a mutable optional variable and available on
 	// each resolve function via: `graphql.ResolveParams.Info.RootValue`.

--- a/examples/sql-nullstring/main.go
+++ b/examples/sql-nullstring/main.go
@@ -4,9 +4,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
+
 	"github.com/machship/graphql"
 	"github.com/machship/graphql/language/ast"
-	"log"
 )
 
 // NullString to be used in place of sql.NullString
@@ -51,7 +52,7 @@ func NewNullString(value string) *NullString {
 }
 
 // SerializeNullString serializes `NullString` to a string
-func SerializeNullString(value interface{}) interface{} {
+func SerializeNullString(value any) any {
 	switch value := value.(type) {
 	case NullString:
 		return value.String
@@ -64,7 +65,7 @@ func SerializeNullString(value interface{}) interface{} {
 }
 
 // ParseNullString parses GraphQL variables from `string` to `CustomID`
-func ParseNullString(value interface{}) interface{} {
+func ParseNullString(value any) any {
 	switch value := value.(type) {
 	case string:
 		return NewNullString(value)
@@ -76,7 +77,7 @@ func ParseNullString(value interface{}) interface{} {
 }
 
 // ParseLiteralNullString parses GraphQL AST value to `NullString`.
-func ParseLiteralNullString(valueAST ast.Value) interface{} {
+func ParseLiteralNullString(valueAST ast.Value) any {
 	switch valueAST := valueAST.(type) {
 	case *ast.StringValue:
 		return NewNullString(valueAST.Value)
@@ -132,7 +133,7 @@ func main() {
 							Type: NullableString,
 						},
 					},
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(p graphql.ResolveParams) (any, error) {
 						dog, dogOk := p.Args["favorite_dog"].(*NullString)
 						people := []Person{
 							Person{Name: "Alice", FavoriteDog: NewNullString("Yorkshire Terrier")},

--- a/examples/sql-nullstring/main.go
+++ b/examples/sql-nullstring/main.go
@@ -136,10 +136,10 @@ func main() {
 					Resolve: func(p graphql.ResolveParams) (any, error) {
 						dog, dogOk := p.Args["favorite_dog"].(*NullString)
 						people := []Person{
-							Person{Name: "Alice", FavoriteDog: NewNullString("Yorkshire Terrier")},
+							{Name: "Alice", FavoriteDog: NewNullString("Yorkshire Terrier")},
 							// `Bob`'s favorite dog will be saved as null in the database
-							Person{Name: "Bob", FavoriteDog: NewNullString("")},
-							Person{Name: "Chris", FavoriteDog: NewNullString("French Bulldog")},
+							{Name: "Bob", FavoriteDog: NewNullString("")},
+							{Name: "Chris", FavoriteDog: NewNullString("French Bulldog")},
 						}
 						switch {
 						case dogOk:

--- a/examples/todo/main.go
+++ b/examples/todo/main.go
@@ -3,9 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"net/http"
-	"time"
 
 	"github.com/machship/graphql"
 	"github.com/machship/graphql/examples/todo/schema"
@@ -16,8 +14,6 @@ func init() {
 	todo2 := schema.Todo{ID: "b", Text: "This is the most important", Done: false}
 	todo3 := schema.Todo{ID: "c", Text: "Please do this or else", Done: false}
 	schema.TodoList = append(schema.TodoList, todo1, todo2, todo3)
-
-	rand.Seed(time.Now().UnixNano())
 }
 
 func executeQuery(query string, schema graphql.Schema) *graphql.Result {

--- a/examples/todo/schema/schema.go
+++ b/examples/todo/schema/schema.go
@@ -58,7 +58,7 @@ var rootMutation = graphql.NewObject(graphql.ObjectConfig{
 					Type: graphql.NewNonNull(graphql.String),
 				},
 			},
-			Resolve: func(params graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(params graphql.ResolveParams) (any, error) {
 
 				// marshall and cast the argument value
 				text, _ := params.Args["text"].(string)
@@ -98,7 +98,7 @@ var rootMutation = graphql.NewObject(graphql.ObjectConfig{
 					Type: graphql.NewNonNull(graphql.String),
 				},
 			},
-			Resolve: func(params graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(params graphql.ResolveParams) (any, error) {
 				// marshall and cast the argument value
 				done, _ := params.Args["done"].(bool)
 				id, _ := params.Args["id"].(string)
@@ -139,7 +139,7 @@ var rootQuery = graphql.NewObject(graphql.ObjectConfig{
 					Type: graphql.String,
 				},
 			},
-			Resolve: func(params graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(params graphql.ResolveParams) (any, error) {
 
 				idQuery, isOK := params.Args["id"].(string)
 				if isOK {
@@ -158,7 +158,7 @@ var rootQuery = graphql.NewObject(graphql.ObjectConfig{
 		"lastTodo": &graphql.Field{
 			Type:        todoType,
 			Description: "Last todo added",
-			Resolve: func(params graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(params graphql.ResolveParams) (any, error) {
 				return TodoList[len(TodoList)-1], nil
 			},
 		},
@@ -169,7 +169,7 @@ var rootQuery = graphql.NewObject(graphql.ObjectConfig{
 		"todoList": &graphql.Field{
 			Type:        graphql.NewList(todoType),
 			Description: "List of todos",
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(p graphql.ResolveParams) (any, error) {
 				return TodoList, nil
 			},
 		},

--- a/executor.go
+++ b/executor.go
@@ -70,7 +70,7 @@ func Execute(p ExecuteParams) (result *Result) {
 		})
 
 		if err != nil {
-			result.Errors = append(result.Errors, gqlerrors.FormatError(err.(error)))
+			result.Errors = append(result.Errors, gqlerrors.FormatError(err))
 			resultChannel <- result
 			return
 		}
@@ -121,7 +121,7 @@ func buildExecutionContext(p buildExecutionCtxParams) (*executionContext, error)
 		switch definition := definition.(type) {
 		case *ast.OperationDefinition:
 			if (p.OperationName == "") && operation != nil {
-				return nil, errors.New("Must provide operation name if query contains multiple operations.")
+				return nil, errors.New("must provide operation name if query contains multiple operations")
 			}
 			if p.OperationName == "" || definition.GetName() != nil && definition.GetName().Value == p.OperationName {
 				operation = definition
@@ -139,9 +139,9 @@ func buildExecutionContext(p buildExecutionCtxParams) (*executionContext, error)
 
 	if operation == nil {
 		if p.OperationName != "" {
-			return nil, fmt.Errorf(`Unknown operation named "%v".`, p.OperationName)
+			return nil, fmt.Errorf(`unknown operation named "%v"`, p.OperationName)
 		}
-		return nil, fmt.Errorf(`Must provide an operation.`)
+		return nil, fmt.Errorf(`must provide an operation`)
 	}
 
 	variableValues, err := getVariableValues(p.Schema, operation.GetVariableDefinitions(), p.Args)
@@ -193,7 +193,7 @@ func executeOperation(p executeOperationParams) *Result {
 // Extracts the root type of the operation from the schema.
 func getOperationRootType(schema Schema, operation ast.Definition) (*Object, error) {
 	if operation == nil {
-		return nil, errors.New("Can only execute queries, mutations and subscription")
+		return nil, errors.New("can only execute queries, mutations and subscription")
 	}
 
 	switch operation.GetOperation() {
@@ -913,11 +913,7 @@ func defaultResolveTypeFn(p ResolveTypeParams, abstractType Abstract) *Object {
 		if possibleType.IsTypeOf == nil {
 			continue
 		}
-		isTypeOfParams := IsTypeOfParams{
-			Value:   p.Value,
-			Info:    p.Info,
-			Context: p.Context,
-		}
+		isTypeOfParams := IsTypeOfParams(p)
 		if res := possibleType.IsTypeOf(isTypeOfParams); res {
 			return possibleType
 		}

--- a/executor.go
+++ b/executor.go
@@ -14,10 +14,10 @@ import (
 
 type ExecuteParams struct {
 	Schema        Schema
-	Root          interface{}
+	Root          any
 	AST           *ast.Document
 	OperationName string
-	Args          map[string]interface{}
+	Args          map[string]any
 
 	// Context may be provided to pass application-specific per-request
 	// information to resolve functions.
@@ -94,10 +94,10 @@ func Execute(p ExecuteParams) (result *Result) {
 
 type buildExecutionCtxParams struct {
 	Schema        Schema
-	Root          interface{}
+	Root          any
 	AST           *ast.Document
 	OperationName string
-	Args          map[string]interface{}
+	Args          map[string]any
 	Result        *Result
 	Context       context.Context
 }
@@ -105,9 +105,9 @@ type buildExecutionCtxParams struct {
 type executionContext struct {
 	Schema         Schema
 	Fragments      map[string]ast.Definition
-	Root           interface{}
+	Root           any
 	Operation      ast.Definition
-	VariableValues map[string]interface{}
+	VariableValues map[string]any
 	Errors         []gqlerrors.FormattedError
 	Context        context.Context
 }
@@ -160,7 +160,7 @@ func buildExecutionContext(p buildExecutionCtxParams) (*executionContext, error)
 
 type executeOperationParams struct {
 	ExecutionContext *executionContext
-	Root             interface{}
+	Root             any
 	Operation        ast.Definition
 }
 
@@ -240,7 +240,7 @@ func getOperationRootType(schema Schema, operation ast.Definition) (*Object, err
 type executeFieldsParams struct {
 	ExecutionContext *executionContext
 	ParentType       *Object
-	Source           interface{}
+	Source           any
 	Fields           map[string][]*ast.Field
 	Path             *ResponsePath
 }
@@ -248,13 +248,13 @@ type executeFieldsParams struct {
 // Implements the "Evaluating selection sets" section of the spec for "write" mode.
 func executeFieldsSerially(p executeFieldsParams) *Result {
 	if p.Source == nil {
-		p.Source = map[string]interface{}{}
+		p.Source = map[string]any{}
 	}
 	if p.Fields == nil {
 		p.Fields = map[string][]*ast.Field{}
 	}
 
-	finalResults := make(map[string]interface{}, len(p.Fields))
+	finalResults := make(map[string]any, len(p.Fields))
 	for _, orderedField := range orderedFields(p.Fields) {
 		responseName := orderedField.responseName
 		fieldASTs := orderedField.fieldASTs
@@ -285,16 +285,16 @@ func executeFields(p executeFieldsParams) *Result {
 	}
 }
 
-func executeSubFields(p executeFieldsParams) map[string]interface{} {
+func executeSubFields(p executeFieldsParams) map[string]any {
 
 	if p.Source == nil {
-		p.Source = map[string]interface{}{}
+		p.Source = map[string]any{}
 	}
 	if p.Fields == nil {
 		p.Fields = map[string][]*ast.Field{}
 	}
 
-	finalResults := make(map[string]interface{}, len(p.Fields))
+	finalResults := make(map[string]any, len(p.Fields))
 	for _, orderedField := range orderedFields(p.Fields) {
 		fieldPath := p.Path.WithKey(orderedField.responseName)
 		resolved, state := resolveField(p.ExecutionContext, p.ParentType, p.Source, orderedField.fieldASTs, fieldPath)
@@ -326,7 +326,7 @@ func (d *dethunkQueue) shift() func() {
 // in the map values and replacing each thunk with that thunk's return value. This parallels
 // the reference graphql-js implementation, which calls Promise.all on thunks at each depth (which
 // is an implicit parallel descent).
-func dethunkMapWithBreadthFirstTraversal(finalResults map[string]interface{}) {
+func dethunkMapWithBreadthFirstTraversal(finalResults map[string]any) {
 	dethunkQueue := &dethunkQueue{DethunkFuncs: []func(){}}
 	dethunkMapBreadthFirst(finalResults, dethunkQueue)
 	for len(dethunkQueue.DethunkFuncs) > 0 {
@@ -335,29 +335,29 @@ func dethunkMapWithBreadthFirstTraversal(finalResults map[string]interface{}) {
 	}
 }
 
-func dethunkMapBreadthFirst(m map[string]interface{}, dethunkQueue *dethunkQueue) {
+func dethunkMapBreadthFirst(m map[string]any, dethunkQueue *dethunkQueue) {
 	for k, v := range m {
-		if f, ok := v.(func() interface{}); ok {
+		if f, ok := v.(func() any); ok {
 			m[k] = f()
 		}
 		switch val := m[k].(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			dethunkQueue.push(func() { dethunkMapBreadthFirst(val, dethunkQueue) })
-		case []interface{}:
+		case []any:
 			dethunkQueue.push(func() { dethunkListBreadthFirst(val, dethunkQueue) })
 		}
 	}
 }
 
-func dethunkListBreadthFirst(list []interface{}, dethunkQueue *dethunkQueue) {
+func dethunkListBreadthFirst(list []any, dethunkQueue *dethunkQueue) {
 	for i, v := range list {
-		if f, ok := v.(func() interface{}); ok {
+		if f, ok := v.(func() any); ok {
 			list[i] = f()
 		}
 		switch val := list[i].(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			dethunkQueue.push(func() { dethunkMapBreadthFirst(val, dethunkQueue) })
-		case []interface{}:
+		case []any:
 			dethunkQueue.push(func() { dethunkListBreadthFirst(val, dethunkQueue) })
 		}
 	}
@@ -367,29 +367,29 @@ func dethunkListBreadthFirst(list []interface{}, dethunkQueue *dethunkQueue) {
 // in the map values and replacing each thunk with that thunk's return value. This is needed
 // to conform to the graphql-js reference implementation, which requires serial (depth-first)
 // implementations for mutation selects.
-func dethunkMapDepthFirst(m map[string]interface{}) {
+func dethunkMapDepthFirst(m map[string]any) {
 	for k, v := range m {
-		if f, ok := v.(func() interface{}); ok {
+		if f, ok := v.(func() any); ok {
 			m[k] = f()
 		}
 		switch val := m[k].(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			dethunkMapDepthFirst(val)
-		case []interface{}:
+		case []any:
 			dethunkListDepthFirst(val)
 		}
 	}
 }
 
-func dethunkListDepthFirst(list []interface{}) {
+func dethunkListDepthFirst(list []any) {
 	for i, v := range list {
-		if f, ok := v.(func() interface{}); ok {
+		if f, ok := v.(func() any); ok {
 			list[i] = f()
 		}
 		switch val := list[i].(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			dethunkMapDepthFirst(val)
-		case []interface{}:
+		case []any:
 			dethunkListDepthFirst(val)
 		}
 	}
@@ -483,7 +483,7 @@ func collectFields(p collectFieldsParams) (fields map[string][]*ast.Field) {
 func shouldIncludeNode(eCtx *executionContext, directives []*ast.Directive) bool {
 	var (
 		skipAST, includeAST *ast.Directive
-		argValues           map[string]interface{}
+		argValues           map[string]any
 	)
 	for _, directive := range directives {
 		if directive == nil || directive.Name == nil {
@@ -580,7 +580,7 @@ type resolveFieldResultState struct {
 	hasNoFieldDefs bool
 }
 
-func handleFieldError(r interface{}, fieldNodes []ast.Node, path *ResponsePath, returnType Output, eCtx *executionContext) {
+func handleFieldError(r any, fieldNodes []ast.Node, path *ResponsePath, returnType Output, eCtx *executionContext) {
 	err := NewLocatedErrorWithPath(r, fieldNodes, path.AsArray())
 	// send panic upstream
 	if _, ok := returnType.(*NonNull); ok {
@@ -593,10 +593,10 @@ func handleFieldError(r interface{}, fieldNodes []ast.Node, path *ResponsePath, 
 // figures out the value that the field returns by calling its resolve function,
 // then calls completeValue to complete promises, serialize scalars, or execute
 // the sub-selection-set for objects.
-func resolveField(eCtx *executionContext, parentType *Object, source interface{}, fieldASTs []*ast.Field, path *ResponsePath) (result interface{}, resultState resolveFieldResultState) {
+func resolveField(eCtx *executionContext, parentType *Object, source any, fieldASTs []*ast.Field, path *ResponsePath) (result any, resultState resolveFieldResultState) {
 	// catch panic from resolveFn
 	var returnType Output
-	defer func() (interface{}, resolveFieldResultState) {
+	defer func() (any, resolveFieldResultState) {
 		if r := recover(); r != nil {
 			handleFieldError(r, FieldASTsToNodeASTs(fieldASTs), path, returnType, eCtx)
 			return result, resultState
@@ -666,9 +666,9 @@ func resolveField(eCtx *executionContext, parentType *Object, source interface{}
 	return completed, resultState
 }
 
-func completeValueCatchingError(eCtx *executionContext, returnType Type, fieldASTs []*ast.Field, info ResolveInfo, path *ResponsePath, result interface{}) (completed interface{}) {
+func completeValueCatchingError(eCtx *executionContext, returnType Type, fieldASTs []*ast.Field, info ResolveInfo, path *ResponsePath, result any) (completed any) {
 	// catch panic
-	defer func() interface{} {
+	defer func() any {
 		if r := recover(); r != nil {
 			handleFieldError(r, FieldASTsToNodeASTs(fieldASTs), path, returnType, eCtx)
 			return completed
@@ -684,11 +684,11 @@ func completeValueCatchingError(eCtx *executionContext, returnType Type, fieldAS
 	return completed
 }
 
-func completeValue(eCtx *executionContext, returnType Type, fieldASTs []*ast.Field, info ResolveInfo, path *ResponsePath, result interface{}) interface{} {
+func completeValue(eCtx *executionContext, returnType Type, fieldASTs []*ast.Field, info ResolveInfo, path *ResponsePath, result any) any {
 
 	resultVal := reflect.ValueOf(result)
 	if resultVal.IsValid() && resultVal.Kind() == reflect.Func {
-		return func() interface{} {
+		return func() any {
 			return completeThunkValueCatchingError(eCtx, returnType, fieldASTs, info, path, result)
 		}
 	}
@@ -751,7 +751,7 @@ func completeValue(eCtx *executionContext, returnType Type, fieldASTs []*ast.Fie
 	return nil
 }
 
-func completeThunkValueCatchingError(eCtx *executionContext, returnType Type, fieldASTs []*ast.Field, info ResolveInfo, path *ResponsePath, result interface{}) (completed interface{}) {
+func completeThunkValueCatchingError(eCtx *executionContext, returnType Type, fieldASTs []*ast.Field, info ResolveInfo, path *ResponsePath, result any) (completed any) {
 
 	// catch any panic invoked from the propertyFn (thunk)
 	defer func() {
@@ -760,9 +760,9 @@ func completeThunkValueCatchingError(eCtx *executionContext, returnType Type, fi
 		}
 	}()
 
-	propertyFn, ok := result.(func() (interface{}, error))
+	propertyFn, ok := result.(func() (any, error))
 	if !ok {
-		err := gqlerrors.NewFormattedError("Error resolving func. Expected `func() (interface{}, error)` signature")
+		err := gqlerrors.NewFormattedError("Error resolving func. Expected `func() (any, error)` signature")
 		panic(gqlerrors.FormatError(err))
 	}
 	fnResult, err := propertyFn()
@@ -783,7 +783,7 @@ func completeThunkValueCatchingError(eCtx *executionContext, returnType Type, fi
 
 // completeAbstractValue completes value of an Abstract type (Union / Interface) by determining the runtime type
 // of that value, then completing based on that type.
-func completeAbstractValue(eCtx *executionContext, returnType Abstract, fieldASTs []*ast.Field, info ResolveInfo, path *ResponsePath, result interface{}) interface{} {
+func completeAbstractValue(eCtx *executionContext, returnType Abstract, fieldASTs []*ast.Field, info ResolveInfo, path *ResponsePath, result any) any {
 
 	var runtimeType *Object
 
@@ -818,7 +818,7 @@ func completeAbstractValue(eCtx *executionContext, returnType Abstract, fieldAST
 }
 
 // completeObjectValue complete an Object value by executing all sub-selections.
-func completeObjectValue(eCtx *executionContext, returnType *Object, fieldASTs []*ast.Field, info ResolveInfo, path *ResponsePath, result interface{}) interface{} {
+func completeObjectValue(eCtx *executionContext, returnType *Object, fieldASTs []*ast.Field, info ResolveInfo, path *ResponsePath, result any) any {
 
 	// If there is an isTypeOf predicate function, call it with the
 	// current result. If isTypeOf returns false, then raise an error rather
@@ -866,7 +866,7 @@ func completeObjectValue(eCtx *executionContext, returnType *Object, fieldASTs [
 }
 
 // completeLeafValue complete a leaf value (Scalar / Enum) by serializing to a valid value, returning nil if serialization is not possible.
-func completeLeafValue(returnType Leaf, result interface{}) interface{} {
+func completeLeafValue(returnType Leaf, result any) any {
 	serializedResult := returnType.Serialize(result)
 	if isNullish(serializedResult) {
 		return nil
@@ -875,7 +875,7 @@ func completeLeafValue(returnType Leaf, result interface{}) interface{} {
 }
 
 // completeListValue complete a list value by completing each item in the list with the inner type
-func completeListValue(eCtx *executionContext, returnType *List, fieldASTs []*ast.Field, info ResolveInfo, path *ResponsePath, result interface{}) interface{} {
+func completeListValue(eCtx *executionContext, returnType *List, fieldASTs []*ast.Field, info ResolveInfo, path *ResponsePath, result any) any {
 	resultVal := reflect.ValueOf(result)
 	if resultVal.Kind() == reflect.Ptr {
 		resultVal = resultVal.Elem()
@@ -894,7 +894,7 @@ func completeListValue(eCtx *executionContext, returnType *List, fieldASTs []*as
 	}
 
 	itemType := returnType.OfType
-	completedResults := make([]interface{}, 0, resultVal.Len())
+	completedResults := make([]any, 0, resultVal.Len())
 	for i := 0; i < resultVal.Len(); i++ {
 		val := resultVal.Index(i).Interface()
 		fieldPath := path.WithKey(i)
@@ -928,14 +928,14 @@ func defaultResolveTypeFn(p ResolveTypeParams, abstractType Abstract) *Object {
 // FieldResolver is used in DefaultResolveFn when the the source value implements this interface.
 type FieldResolver interface {
 	// Resolve resolves the value for the given ResolveParams. It has the same semantics as FieldResolveFn.
-	Resolve(p ResolveParams) (interface{}, error)
+	Resolve(p ResolveParams) (any, error)
 }
 
 // DefaultResolveFn If a resolve function is not given, then a default resolve behavior is used
 // which takes the property of the source object of the same name as the field
 // and returns it as the result, or if it's a function, returns the result
 // of calling that function.
-func DefaultResolveFn(p ResolveParams) (interface{}, error) {
+func DefaultResolveFn(p ResolveParams) (any, error) {
 	sourceVal := reflect.ValueOf(p.Source)
 	// Check if value implements 'Resolver' interface
 	if resolver, ok := sourceVal.Interface().(FieldResolver); ok {
@@ -980,13 +980,13 @@ func DefaultResolveFn(p ResolveParams) (interface{}, error) {
 	}
 
 	// try p.Source as a map[string]interface
-	if sourceMap, ok := p.Source.(map[string]interface{}); ok {
+	if sourceMap, ok := p.Source.(map[string]any); ok {
 		property := sourceMap[p.Info.FieldName]
 		val := reflect.ValueOf(property)
 		if val.IsValid() && val.Type().Kind() == reflect.Func {
 			// try type casting the func to the most basic func signature
 			// for more complex signatures, user have to define ResolveFn
-			if propertyFn, ok := property.(func() interface{}); ok {
+			if propertyFn, ok := property.(func() any); ok {
 				return propertyFn(), nil
 			}
 		}
@@ -1001,7 +1001,7 @@ func DefaultResolveFn(p ResolveParams) (interface{}, error) {
 			if val.Type().Kind() == reflect.Func {
 				// try type casting the func to the most basic func signature
 				// for more complex signatures, user have to define ResolveFn
-				if propertyFn, ok := property.(func() interface{}); ok {
+				if propertyFn, ok := property.(func() any); ok {
 					return propertyFn(), nil
 				}
 			}

--- a/executor_resolve_test.go
+++ b/executor_resolve_test.go
@@ -2,10 +2,11 @@ package graphql_test
 
 import (
 	"encoding/json"
-	"github.com/machship/graphql"
-	"github.com/machship/graphql/testutil"
 	"reflect"
 	"testing"
+
+	"github.com/machship/graphql"
+	"github.com/machship/graphql/testutil"
 )
 
 func testSchema(t *testing.T, testField *graphql.Field) graphql.Schema {
@@ -26,11 +27,11 @@ func testSchema(t *testing.T, testField *graphql.Field) graphql.Schema {
 func TestExecutesResolveFunction_DefaultFunctionAccessesProperties(t *testing.T) {
 	schema := testSchema(t, &graphql.Field{Type: graphql.String})
 
-	source := map[string]interface{}{
+	source := map[string]any{
 		"test": "testValue",
 	}
 
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"test": "testValue",
 	}
 
@@ -47,13 +48,13 @@ func TestExecutesResolveFunction_DefaultFunctionAccessesProperties(t *testing.T)
 func TestExecutesResolveFunction_DefaultFunctionCallsMethods(t *testing.T) {
 	schema := testSchema(t, &graphql.Field{Type: graphql.String})
 
-	source := map[string]interface{}{
-		"test": func() interface{} {
+	source := map[string]any{
+		"test": func() any {
 			return "testValue"
 		},
 	}
 
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"test": "testValue",
 	}
 
@@ -74,13 +75,13 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction(t *testing.T) {
 			"aStr": &graphql.ArgumentConfig{Type: graphql.String},
 			"aInt": &graphql.ArgumentConfig{Type: graphql.Int},
 		},
-		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+		Resolve: func(p graphql.ResolveParams) (any, error) {
 			b, err := json.Marshal(p.Args)
 			return string(b), err
 		},
 	})
 
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"test": "{}",
 	}
 	result := graphql.Do(graphql.Params{
@@ -91,7 +92,7 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction(t *testing.T) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result.Data))
 	}
 
-	expected = map[string]interface{}{
+	expected = map[string]any{
 		"test": `{"aStr":"String!"}`,
 	}
 	result = graphql.Do(graphql.Params{
@@ -102,7 +103,7 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction(t *testing.T) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result.Data))
 	}
 
-	expected = map[string]interface{}{
+	expected = map[string]any{
 		"test": `{"aInt":-123,"aStr":"String!"}`,
 	}
 	result = graphql.Do(graphql.Params{
@@ -135,7 +136,7 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_With
 			"aStr": &graphql.ArgumentConfig{Type: graphql.String},
 			"aInt": &graphql.ArgumentConfig{Type: graphql.Int},
 		},
-		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+		Resolve: func(p graphql.ResolveParams) (any, error) {
 			aStr, _ := p.Args["aStr"].(string)
 			aInt, _ := p.Args["aInt"].(int)
 			return &SubObjectWithoutJSONTags{
@@ -145,8 +146,8 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_With
 		},
 	})
 
-	expected := map[string]interface{}{
-		"test": map[string]interface{}{
+	expected := map[string]any{
+		"test": map[string]any{
 			"Str": "",
 			"Int": 0,
 		},
@@ -160,8 +161,8 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_With
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result.Data))
 	}
 
-	expected = map[string]interface{}{
-		"test": map[string]interface{}{
+	expected = map[string]any{
+		"test": map[string]any{
 			"Str": "String!",
 			"Int": 0,
 		},
@@ -174,8 +175,8 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_With
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result.Data))
 	}
 
-	expected = map[string]interface{}{
-		"test": map[string]interface{}{
+	expected = map[string]any{
+		"test": map[string]any{
 			"Str": "String!",
 			"Int": -123,
 		},
@@ -211,7 +212,7 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_With
 			"aStr": &graphql.ArgumentConfig{Type: graphql.String},
 			"aInt": &graphql.ArgumentConfig{Type: graphql.Int},
 		},
-		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+		Resolve: func(p graphql.ResolveParams) (any, error) {
 			aStr, _ := p.Args["aStr"].(string)
 			aInt, _ := p.Args["aInt"].(int)
 			return &SubObjectWithJSONTags{
@@ -221,8 +222,8 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_With
 		},
 	})
 
-	expected := map[string]interface{}{
-		"test": map[string]interface{}{
+	expected := map[string]any{
+		"test": map[string]any{
 			"str": "",
 			"int": 0,
 		},
@@ -236,8 +237,8 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_With
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result.Data))
 	}
 
-	expected = map[string]interface{}{
-		"test": map[string]interface{}{
+	expected = map[string]any{
+		"test": map[string]any{
 			"str": "String!",
 			"int": 0,
 		},
@@ -250,8 +251,8 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_With
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result.Data))
 	}
 
-	expected = map[string]interface{}{
-		"test": map[string]interface{}{
+	expected = map[string]any{
+		"test": map[string]any{
 			"str": "String!",
 			"int": -123,
 		},

--- a/executor_schema_test.go
+++ b/executor_schema_test.go
@@ -29,13 +29,13 @@ type testAuthor struct {
 	RecentArticle *testArticle `json:"recentArticle"`
 }
 type testArticle struct {
-	Id          string        `json:"id"`
-	IsPublished string        `json:"isPublished"`
-	Author      *testAuthor   `json:"author"`
-	Title       string        `json:"title"`
-	Body        string        `json:"body"`
-	Hidden      string        `json:"hidden"`
-	Keywords    []interface{} `json:"keywords"`
+	Id          string      `json:"id"`
+	IsPublished string      `json:"isPublished"`
+	Author      *testAuthor `json:"author"`
+	Title       string      `json:"title"`
+	Body        string      `json:"body"`
+	Hidden      string      `json:"hidden"`
+	Keywords    []any       `json:"keywords"`
 }
 
 func getPic(id int, width, height string) *testPic {
@@ -48,7 +48,7 @@ func getPic(id int, width, height string) *testPic {
 
 var johnSmith *testAuthor
 
-func article(id interface{}) *testArticle {
+func article(id any) *testArticle {
 	return &testArticle{
 		Id:          fmt.Sprintf("%v", id),
 		IsPublished: "true",
@@ -56,7 +56,7 @@ func article(id interface{}) *testArticle {
 		Title:       fmt.Sprintf("My Article %v", id),
 		Body:        "This is a post",
 		Hidden:      "This data is not exposed in the schema",
-		Keywords: []interface{}{
+		Keywords: []any{
 			"foo", "bar", 1, true, nil,
 		},
 	}
@@ -106,7 +106,7 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if author, ok := p.Source.(*testAuthor); ok {
 						width := fmt.Sprintf("%v", p.Args["width"])
 						height := fmt.Sprintf("%v", p.Args["height"])
@@ -156,14 +156,14 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 						Type: graphql.ID,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					id := p.Args["id"]
 					return article(id), nil
 				},
 			},
 			"feed": &graphql.Field{
 				Type: graphql.NewList(blogArticle),
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					return []*testArticle{
 						article(1),
 						article(2),
@@ -223,24 +223,24 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 	`
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"article": map[string]interface{}{
+		Data: map[string]any{
+			"article": map[string]any{
 				"title": "My Article 1",
 				"body":  "This is a post",
-				"author": map[string]interface{}{
+				"author": map[string]any{
 					"id":   "123",
 					"name": "John Smith",
-					"pic": map[string]interface{}{
+					"pic": map[string]any{
 						"url":    "cdn://123",
 						"width":  640,
 						"height": 480,
 					},
-					"recentArticle": map[string]interface{}{
+					"recentArticle": map[string]any{
 						"id":          "1",
 						"isPublished": bool(true),
 						"title":       "My Article 1",
 						"body":        "This is a post",
-						"keywords": []interface{}{
+						"keywords": []any{
 							"foo",
 							"bar",
 							"1",
@@ -252,44 +252,44 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 				"id":          "1",
 				"isPublished": bool(true),
 			},
-			"feed": []interface{}{
-				map[string]interface{}{
+			"feed": []any{
+				map[string]any{
 					"id":    "1",
 					"title": "My Article 1",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"id":    "2",
 					"title": "My Article 2",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"id":    "3",
 					"title": "My Article 3",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"id":    "4",
 					"title": "My Article 4",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"id":    "5",
 					"title": "My Article 5",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"id":    "6",
 					"title": "My Article 6",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"id":    "7",
 					"title": "My Article 7",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"id":    "8",
 					"title": "My Article 8",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"id":    "9",
 					"title": "My Article 9",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"id":    "10",
 					"title": "My Article 10",
 				},

--- a/executor_schema_test.go
+++ b/executor_schema_test.go
@@ -309,7 +309,7 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }

--- a/executor_test.go
+++ b/executor_test.go
@@ -17,27 +17,27 @@ import (
 
 func TestExecutesArbitraryCode(t *testing.T) {
 
-	deepData := map[string]interface{}{}
-	data := map[string]interface{}{
-		"a": func() interface{} { return "Apple" },
-		"b": func() interface{} { return "Banana" },
-		"c": func() interface{} { return "Cookie" },
-		"d": func() interface{} { return "Donut" },
-		"e": func() interface{} { return "Egg" },
+	deepData := map[string]any{}
+	data := map[string]any{
+		"a": func() any { return "Apple" },
+		"b": func() any { return "Banana" },
+		"c": func() any { return "Cookie" },
+		"d": func() any { return "Donut" },
+		"e": func() any { return "Egg" },
 		"f": "Fish",
 		"pic": func(size int) string {
 			return fmt.Sprintf("Pic of size: %v", size)
 		},
-		"deep": func() interface{} { return deepData },
+		"deep": func() any { return deepData },
 	}
-	data["promise"] = func() interface{} {
+	data["promise"] = func() any {
 		return data
 	}
-	deepData = map[string]interface{}{
-		"a":      func() interface{} { return "Already Been Done" },
-		"b":      func() interface{} { return "Boring" },
-		"c":      func() interface{} { return []string{"Contrived", "", "Confusing"} },
-		"deeper": func() interface{} { return []interface{}{data, nil, data} },
+	deepData = map[string]any{
+		"a":      func() any { return "Already Been Done" },
+		"b":      func() any { return "Boring" },
+		"c":      func() any { return []string{"Contrived", "", "Confusing"} },
+		"deeper": func() any { return []any{data, nil, data} },
 	}
 
 	query := `
@@ -71,30 +71,30 @@ func TestExecutesArbitraryCode(t *testing.T) {
     `
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"b": "Banana",
 			"x": "Cookie",
 			"d": "Donut",
 			"e": "Egg",
-			"promise": map[string]interface{}{
+			"promise": map[string]any{
 				"a": "Apple",
 			},
 			"a": "Apple",
-			"deep": map[string]interface{}{
+			"deep": map[string]any{
 				"a": "Already Been Done",
 				"b": "Boring",
-				"c": []interface{}{
+				"c": []any{
 					"Contrived",
 					"",
 					"Confusing",
 				},
-				"deeper": []interface{}{
-					map[string]interface{}{
+				"deeper": []any{
+					map[string]any{
 						"a": "Apple",
 						"b": "Banana",
 					},
 					nil,
-					map[string]interface{}{
+					map[string]any{
 						"a": "Apple",
 						"b": "Banana",
 					},
@@ -106,9 +106,9 @@ func TestExecutesArbitraryCode(t *testing.T) {
 	}
 
 	// Schema Definitions
-	picResolverFn := func(p graphql.ResolveParams) (interface{}, error) {
+	picResolverFn := func(p graphql.ResolveParams) (any, error) {
 		// get and type assert ResolveFn for this field
-		picResolver, ok := p.Source.(map[string]interface{})["pic"].(func(size int) string)
+		picResolver, ok := p.Source.(map[string]any)["pic"].(func(size int) string)
 		if !ok {
 			return nil, nil
 		}
@@ -190,7 +190,7 @@ func TestExecutesArbitraryCode(t *testing.T) {
 	astDoc := testutil.TestParse(t, query)
 
 	// execute
-	args := map[string]interface{}{
+	args := map[string]any{
 		"size": 100,
 	}
 	operationName := "Example"
@@ -227,13 +227,13 @@ func TestMergesParallelFragments(t *testing.T) {
     `
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "Apple",
 			"b": "Banana",
-			"deep": map[string]interface{}{
+			"deep": map[string]any{
 				"c": "Cherry",
 				"b": "Banana",
-				"deeper": map[string]interface{}{
+				"deeper": map[string]any{
 					"b": "Banana",
 					"c": "Cherry",
 				},
@@ -247,19 +247,19 @@ func TestMergesParallelFragments(t *testing.T) {
 		Fields: graphql.Fields{
 			"a": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					return "Apple", nil
 				},
 			},
 			"b": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					return "Banana", nil
 				},
 			},
 			"c": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					return "Cherry", nil
 				},
 			},
@@ -267,7 +267,7 @@ func TestMergesParallelFragments(t *testing.T) {
 	})
 	deepTypeFieldConfig := &graphql.Field{
 		Type: typeObjectType,
-		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+		Resolve: func(p graphql.ResolveParams) (any, error) {
 			return p.Source, nil
 		},
 	}
@@ -297,7 +297,7 @@ func TestMergesParallelFragments(t *testing.T) {
 	}
 }
 
-type CustomMap map[string]interface{}
+type CustomMap map[string]any
 
 func TestCustomMapType(t *testing.T) {
 	query := `
@@ -323,7 +323,7 @@ func TestCustomMapType(t *testing.T) {
 							},
 						},
 					}),
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(p graphql.ResolveParams) (any, error) {
 						return data, nil
 					},
 				},
@@ -343,8 +343,8 @@ func TestCustomMapType(t *testing.T) {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
 
-	expected := map[string]interface{}{
-		"data": map[string]interface{}{
+	expected := map[string]any{
+		"data": map[string]any{
 			"a": "1",
 		},
 	}
@@ -359,11 +359,11 @@ func TestThreadsSourceCorrectly(t *testing.T) {
       query Example { a }
     `
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"key": "value",
 	}
 
-	var resolvedSource map[string]interface{}
+	var resolvedSource map[string]any
 
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
@@ -371,8 +371,8 @@ func TestThreadsSourceCorrectly(t *testing.T) {
 			Fields: graphql.Fields{
 				"a": &graphql.Field{
 					Type: graphql.String,
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-						resolvedSource = p.Source.(map[string]interface{})
+					Resolve: func(p graphql.ResolveParams) (any, error) {
+						resolvedSource = p.Source.(map[string]any)
 						return resolvedSource, nil
 					},
 				},
@@ -411,7 +411,7 @@ func TestCorrectlyThreadsArguments(t *testing.T) {
       }
     `
 
-	var resolvedArgs map[string]interface{}
+	var resolvedArgs map[string]any
 
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
@@ -427,7 +427,7 @@ func TestCorrectlyThreadsArguments(t *testing.T) {
 						},
 					},
 					Type: graphql.String,
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(p graphql.ResolveParams) (any, error) {
 						resolvedArgs = p.Args
 						return resolvedArgs, nil
 					},
@@ -474,8 +474,8 @@ func TestThreadsRootValueContextCorrectly(t *testing.T) {
 			Fields: graphql.Fields{
 				"a": &graphql.Field{
 					Type: graphql.String,
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-						val, _ := p.Info.RootValue.(map[string]interface{})["stringKey"].(string)
+					Resolve: func(p graphql.ResolveParams) (any, error) {
+						val, _ := p.Info.RootValue.(map[string]any)["stringKey"].(string)
 						return val, nil
 					},
 				},
@@ -493,7 +493,7 @@ func TestThreadsRootValueContextCorrectly(t *testing.T) {
 	ep := graphql.ExecuteParams{
 		Schema: schema,
 		AST:    ast,
-		Root: map[string]interface{}{
+		Root: map[string]any{
 			"stringKey": "stringValue",
 		},
 	}
@@ -503,7 +503,7 @@ func TestThreadsRootValueContextCorrectly(t *testing.T) {
 	}
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "stringValue",
 		},
 	}
@@ -524,7 +524,7 @@ func TestThreadsContextCorrectly(t *testing.T) {
 			Fields: graphql.Fields{
 				"a": &graphql.Field{
 					Type: graphql.String,
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(p graphql.ResolveParams) (any, error) {
 						return p.Context.Value("foo"), nil
 					},
 				},
@@ -550,7 +550,7 @@ func TestThreadsContextCorrectly(t *testing.T) {
 	}
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "bar",
 		},
 	}
@@ -567,7 +567,7 @@ func TestNullsOutErrorSubtrees(t *testing.T) {
       syncError,
     }`
 
-	expectedData := map[string]interface{}{
+	expectedData := map[string]any{
 		"sync":      "sync",
 		"syncError": nil,
 	}
@@ -578,17 +578,17 @@ func TestNullsOutErrorSubtrees(t *testing.T) {
 				Line: 3, Column: 7,
 			},
 		},
-		Path: []interface{}{
+		Path: []any{
 			"syncError",
 		},
 	},
 	}
 
-	data := map[string]interface{}{
-		"sync": func() interface{} {
+	data := map[string]any{
+		"sync": func() any {
 			return "sync"
 		},
-		"syncError": func() interface{} {
+		"syncError": func() any {
 			panic("Error getting syncError")
 		},
 	}
@@ -630,12 +630,12 @@ func TestNullsOutErrorSubtrees(t *testing.T) {
 func TestUsesTheInlineOperationIfNoOperationNameIsProvided(t *testing.T) {
 
 	doc := `{ a }`
-	data := map[string]interface{}{
+	data := map[string]any{
 		"a": "b",
 	}
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "b",
 		},
 	}
@@ -675,12 +675,12 @@ func TestUsesTheInlineOperationIfNoOperationNameIsProvided(t *testing.T) {
 func TestUsesTheOnlyOperationIfNoOperationNameIsProvided(t *testing.T) {
 
 	doc := `query Example { a }`
-	data := map[string]interface{}{
+	data := map[string]any{
 		"a": "b",
 	}
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "b",
 		},
 	}
@@ -720,12 +720,12 @@ func TestUsesTheOnlyOperationIfNoOperationNameIsProvided(t *testing.T) {
 func TestUsesTheNamedOperationIfOperationNameIsProvided(t *testing.T) {
 
 	doc := `query Example { first: a } query OtherExample { second: a }`
-	data := map[string]interface{}{
+	data := map[string]any{
 		"a": "b",
 	}
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"second": "b",
 		},
 	}
@@ -765,7 +765,7 @@ func TestUsesTheNamedOperationIfOperationNameIsProvided(t *testing.T) {
 func TestThrowsIfNoOperationIsProvided(t *testing.T) {
 
 	doc := `fragment Example on Type { a }`
-	data := map[string]interface{}{
+	data := map[string]any{
 		"a": "b",
 	}
 
@@ -810,7 +810,7 @@ func TestThrowsIfNoOperationIsProvided(t *testing.T) {
 func TestThrowsIfNoOperationNameIsProvidedWithMultipleOperations(t *testing.T) {
 
 	doc := `query Example { a } query OtherExample { a }`
-	data := map[string]interface{}{
+	data := map[string]any{
 		"a": "b",
 	}
 
@@ -856,7 +856,7 @@ func TestThrowsIfNoOperationNameIsProvidedWithMultipleOperations(t *testing.T) {
 func TestThrowsIfUnknownOperationNameIsProvided(t *testing.T) {
 
 	doc := `query Example { a } query OtherExample { a }`
-	data := map[string]interface{}{
+	data := map[string]any{
 		"a": "b",
 	}
 
@@ -953,13 +953,13 @@ func TestThrowsIfOperationTypeIsUnsupported(t *testing.T) {
 func TestUsesTheQuerySchemaForQueries(t *testing.T) {
 
 	doc := `query Q { a } mutation M { c } subscription S { a }`
-	data := map[string]interface{}{
+	data := map[string]any{
 		"a": "b",
 		"c": "d",
 	}
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "b",
 		},
 	}
@@ -1016,13 +1016,13 @@ func TestUsesTheQuerySchemaForQueries(t *testing.T) {
 func TestUsesTheMutationSchemaForMutations(t *testing.T) {
 
 	doc := `query Q { a } mutation M { c }`
-	data := map[string]interface{}{
+	data := map[string]any{
 		"a": "b",
 		"c": "d",
 	}
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"c": "d",
 		},
 	}
@@ -1071,13 +1071,13 @@ func TestUsesTheMutationSchemaForMutations(t *testing.T) {
 func TestUsesTheSubscriptionSchemaForSubscriptions(t *testing.T) {
 
 	doc := `query Q { a } subscription S { a }`
-	data := map[string]interface{}{
+	data := map[string]any{
 		"a": "b",
 		"c": "d",
 	}
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "b",
 		},
 	}
@@ -1134,16 +1134,16 @@ func TestCorrectFieldOrderingDespiteExecutionOrder(t *testing.T) {
       e
     }
 	`
-	data := map[string]interface{}{
-		"a": func() interface{} { return "a" },
-		"b": func() interface{} { return "b" },
-		"c": func() interface{} { return "c" },
-		"d": func() interface{} { return "d" },
-		"e": func() interface{} { return "e" },
+	data := map[string]any{
+		"a": func() any { return "a" },
+		"b": func() any { return "b" },
+		"c": func() any { return "c" },
+		"d": func() any { return "d" },
+		"e": func() any { return "e" },
 	}
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "a",
 			"b": "b",
 			"c": "c",
@@ -1220,12 +1220,12 @@ func TestAvoidsRecursion(t *testing.T) {
         ...Frag
       }
     `
-	data := map[string]interface{}{
+	data := map[string]any{
 		"a": "b",
 	}
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "b",
 		},
 	}
@@ -1271,7 +1271,7 @@ func TestDoesNotIncludeIllegalFieldsInOutput(t *testing.T) {
     }`
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{},
+		Data: map[string]any{},
 	}
 
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
@@ -1318,7 +1318,7 @@ func TestDoesNotIncludeArgumentsThatWereNotSet(t *testing.T) {
 	doc := `{ field(a: true, c: false, e: 0) }`
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"field": `{"a":true,"c":false,"e":0}`,
 		},
 	}
@@ -1346,7 +1346,7 @@ func TestDoesNotIncludeArgumentsThatWereNotSet(t *testing.T) {
 							Type: graphql.Int,
 						},
 					},
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(p graphql.ResolveParams) (any, error) {
 						args, _ := json.Marshal(p.Args)
 						return string(args), nil
 					},
@@ -1386,17 +1386,17 @@ func TestFailsWhenAnIsTypeOfCheckIsNotMet(t *testing.T) {
 
 	query := `{ specials { value } }`
 
-	data := map[string]interface{}{
-		"specials": []interface{}{
+	data := map[string]any{
+		"specials": []any{
 			testSpecialType{"foo"},
 			testNotSpecialType{"bar"},
 		},
 	}
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"specials": []interface{}{
-				map[string]interface{}{
+		Data: map[string]any{
+			"specials": []any{
+				map[string]any{
 					"value": "foo",
 				},
 				nil,
@@ -1410,7 +1410,7 @@ func TestFailsWhenAnIsTypeOfCheckIsNotMet(t *testing.T) {
 					Column: 3,
 				},
 			},
-			Path: []interface{}{
+			Path: []any{
 				"specials",
 				1,
 			},
@@ -1429,7 +1429,7 @@ func TestFailsWhenAnIsTypeOfCheckIsNotMet(t *testing.T) {
 		Fields: graphql.Fields{
 			"value": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					return p.Source.(testSpecialType).Value, nil
 				},
 			},
@@ -1441,8 +1441,8 @@ func TestFailsWhenAnIsTypeOfCheckIsNotMet(t *testing.T) {
 			Fields: graphql.Fields{
 				"specials": &graphql.Field{
 					Type: graphql.NewList(specialType),
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-						return p.Source.(map[string]interface{})["specials"], nil
+					Resolve: func(p graphql.ResolveParams) (any, error) {
+						return p.Source.(map[string]any)["specials"], nil
 					},
 				},
 			},
@@ -1519,13 +1519,13 @@ func TestQuery_ExecutionAddsErrorsFromFieldResolveFn(t *testing.T) {
 		Fields: graphql.Fields{
 			"a": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					return nil, qError
 				},
 			},
 			"b": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					return "ok", nil
 				},
 			},
@@ -1557,13 +1557,13 @@ func TestQuery_ExecutionDoesNotAddErrorsFromFieldResolveFn(t *testing.T) {
 		Fields: graphql.Fields{
 			"a": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					return nil, qError
 				},
 			},
 			"b": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					return "ok", nil
 				},
 			},
@@ -1605,8 +1605,8 @@ func TestQuery_InputObjectUsesFieldDefaultValueFn(t *testing.T) {
 						Type: graphql.NewNonNull(inputType),
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					val := p.Args["foo"].(map[string]interface{})
+				Resolve: func(p graphql.ResolveParams) (any, error) {
+					val := p.Args["foo"].(map[string]any)
 					def, ok := val["default"]
 					if !ok || def == nil {
 						return nil, errors.New("queryError: No 'default' param")
@@ -1655,7 +1655,7 @@ func TestMutation_ExecutionAddsErrorsFromFieldResolveFn(t *testing.T) {
 						Type: graphql.String,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					return nil, mError
 				},
 			},
@@ -1666,7 +1666,7 @@ func TestMutation_ExecutionAddsErrorsFromFieldResolveFn(t *testing.T) {
 						Type: graphql.String,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					return "ok", nil
 				},
 			},
@@ -1712,7 +1712,7 @@ func TestMutation_ExecutionDoesNotAddErrorsFromFieldResolveFn(t *testing.T) {
 						Type: graphql.String,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					return nil, mError
 				},
 			},
@@ -1723,7 +1723,7 @@ func TestMutation_ExecutionDoesNotAddErrorsFromFieldResolveFn(t *testing.T) {
 						Type: graphql.String,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					return "ok", nil
 				},
 			},
@@ -1756,7 +1756,7 @@ func TestGraphqlTag(t *testing.T) {
 	var baz = &graphql.Field{
 		Type:        typeObjectType,
 		Description: "typeObjectType",
-		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+		Resolve: func(p graphql.ResolveParams) (any, error) {
 			t := struct {
 				FooBar string `graphql:"fooBar"`
 			}{"foo bar value"}
@@ -1783,8 +1783,8 @@ func TestGraphqlTag(t *testing.T) {
 	if len(result.Errors) != 0 {
 		t.Fatalf("wrong result, unexpected errors: %+v", result.Errors)
 	}
-	expectedData := map[string]interface{}{
-		"baz": map[string]interface{}{
+	expectedData := map[string]any{
+		"baz": map[string]any{
 			"fooBar": "foo bar value",
 		},
 	}
@@ -1803,14 +1803,14 @@ func TestFieldResolver(t *testing.T) {
 	var baz = &graphql.Field{
 		Type:        typeObjectType,
 		Description: "typeObjectType",
-		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+		Resolve: func(p graphql.ResolveParams) (any, error) {
 			return testCustomResolver{}, nil
 		},
 	}
 	var bazPtr = &graphql.Field{
 		Type:        typeObjectType,
 		Description: "typeObjectType",
-		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+		Resolve: func(p graphql.ResolveParams) (any, error) {
 			return &testCustomResolver{}, nil
 		},
 	}
@@ -1835,11 +1835,11 @@ func TestFieldResolver(t *testing.T) {
 	if len(result.Errors) != 0 {
 		t.Fatalf("wrong result, unexpected errors: %+v", result.Errors)
 	}
-	expectedData := map[string]interface{}{
-		"baz": map[string]interface{}{
+	expectedData := map[string]any{
+		"baz": map[string]any{
 			"fooBar": "foo bar value",
 		},
-		"bazPtr": map[string]interface{}{
+		"bazPtr": map[string]any{
 			"fooBar": "foo bar value",
 		},
 	}
@@ -1850,7 +1850,7 @@ func TestFieldResolver(t *testing.T) {
 
 type testCustomResolver struct{}
 
-func (r testCustomResolver) Resolve(p graphql.ResolveParams) (interface{}, error) {
+func (r testCustomResolver) Resolve(p graphql.ResolveParams) (any, error) {
 	if p.Info.FieldName == "fooBar" {
 		return "foo bar value", nil
 	}
@@ -1874,7 +1874,7 @@ func TestContextDeadline(t *testing.T) {
 			Fields: graphql.Fields{
 				"hello": &graphql.Field{
 					Type: graphql.String,
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(p graphql.ResolveParams) (any, error) {
 						time.Sleep(2 * time.Second)
 						return "world", nil
 					},
@@ -1928,7 +1928,7 @@ func TestThunkResultsProcessedCorrectly(t *testing.T) {
 		Fields: graphql.Fields{
 			"bar": &graphql.Field{
 				Type: barType,
-				Resolve: func(params graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(params graphql.ResolveParams) (any, error) {
 					var bar struct {
 						BazA string
 						BazB string
@@ -1936,7 +1936,7 @@ func TestThunkResultsProcessedCorrectly(t *testing.T) {
 					bar.BazA = "A"
 					bar.BazB = "B"
 
-					thunk := func() (interface{}, error) { return &bar, nil }
+					thunk := func() (any, error) { return &bar, nil }
 					return thunk, nil
 				},
 			},
@@ -1948,7 +1948,7 @@ func TestThunkResultsProcessedCorrectly(t *testing.T) {
 		Fields: graphql.Fields{
 			"foo": &graphql.Field{
 				Type: fooType,
-				Resolve: func(params graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(params graphql.ResolveParams) (any, error) {
 					var foo struct{}
 					return foo, nil
 				},
@@ -1976,11 +1976,11 @@ func TestThunkResultsProcessedCorrectly(t *testing.T) {
 		t.Fatalf("expected no errors, got %v", result.Errors)
 	}
 
-	foo := result.Data.(map[string]interface{})["foo"].(map[string]interface{})
-	bar, ok := foo["bar"].(map[string]interface{})
+	foo := result.Data.(map[string]any)["foo"].(map[string]any)
+	bar, ok := foo["bar"].(map[string]any)
 
 	if !ok {
-		t.Errorf("expected bar to be a map[string]interface{}: actual = %v", reflect.TypeOf(foo["bar"]))
+		t.Errorf("expected bar to be a map[string]any: actual = %v", reflect.TypeOf(foo["bar"]))
 	} else {
 		if got, want := bar["bazA"], "A"; got != want {
 			t.Errorf("foo.bar.bazA: got=%v, want=%v", got, want)
@@ -2010,8 +2010,8 @@ func TestThunkErrorsAreHandledCorrectly(t *testing.T) {
 			},
 			"bazC": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					thunk := func() (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
+					thunk := func() (any, error) {
 						return nil, bazCError
 					}
 					return thunk, nil
@@ -2025,7 +2025,7 @@ func TestThunkErrorsAreHandledCorrectly(t *testing.T) {
 		Fields: graphql.Fields{
 			"bar": &graphql.Field{
 				Type: barType,
-				Resolve: func(params graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(params graphql.ResolveParams) (any, error) {
 					var bar struct {
 						BazA string
 						BazB string
@@ -2033,7 +2033,7 @@ func TestThunkErrorsAreHandledCorrectly(t *testing.T) {
 					bar.BazA = "A"
 					bar.BazB = "B"
 
-					thunk := func() (interface{}, error) {
+					thunk := func() (any, error) {
 						return &bar, nil
 					}
 					return thunk, nil
@@ -2047,7 +2047,7 @@ func TestThunkErrorsAreHandledCorrectly(t *testing.T) {
 		Fields: graphql.Fields{
 			"foo": &graphql.Field{
 				Type: fooType,
-				Resolve: func(params graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(params graphql.ResolveParams) (any, error) {
 					var foo struct{}
 					return foo, nil
 				},
@@ -2069,11 +2069,11 @@ func TestThunkErrorsAreHandledCorrectly(t *testing.T) {
 		RequestString: query,
 	})
 
-	foo := result.Data.(map[string]interface{})["foo"].(map[string]interface{})
-	bar, ok := foo["bar"].(map[string]interface{})
+	foo := result.Data.(map[string]any)["foo"].(map[string]any)
+	bar, ok := foo["bar"].(map[string]any)
 
 	if !ok {
-		t.Errorf("expected bar to be a map[string]interface{}: actual = %v", reflect.TypeOf(foo["bar"]))
+		t.Errorf("expected bar to be a map[string]any: actual = %v", reflect.TypeOf(foo["bar"]))
 	} else {
 		if got, want := bar["bazA"], "A"; got != want {
 			t.Errorf("foo.bar.bazA: got=%v, want=%v", got, want)
@@ -2102,8 +2102,8 @@ func TestThunkErrorsAreHandledCorrectly(t *testing.T) {
 	}
 }
 
-func assertJSON(t *testing.T, expected string, actual interface{}) {
-	var e interface{}
+func assertJSON(t *testing.T, expected string, actual any) {
+	var e any
 	if err := json.Unmarshal([]byte(expected), &e); err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -2111,7 +2111,7 @@ func assertJSON(t *testing.T, expected string, actual interface{}) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	var a interface{}
+	var a any
 	if err := json.Unmarshal(aJSON, &a); err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -2126,16 +2126,16 @@ func assertJSON(t *testing.T, expected string, actual interface{}) {
 
 type extendedError struct {
 	error
-	extensions map[string]interface{}
+	extensions map[string]any
 }
 
-func (err extendedError) Extensions() map[string]interface{} {
+func (err extendedError) Extensions() map[string]any {
 	return err.extensions
 }
 
 var _ gqlerrors.ExtendedError = &extendedError{}
 
-func testErrors(t *testing.T, nameType graphql.Output, extensions map[string]interface{}, formatErrorFn func(err error) error) *graphql.Result {
+func testErrors(t *testing.T, nameType graphql.Output, extensions map[string]any, formatErrorFn func(err error) error) *graphql.Result {
 	type Hero struct {
 		Id      string `graphql:"id"`
 		Name    string
@@ -2157,7 +2157,7 @@ func testErrors(t *testing.T, nameType graphql.Output, extensions map[string]int
 		},
 		"name": &graphql.Field{
 			Type: nameType,
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(p graphql.ResolveParams) (any, error) {
 				hero := p.Source.(Hero)
 				if hero.Name != "" {
 					return hero.Name, nil
@@ -2187,7 +2187,7 @@ func testErrors(t *testing.T, nameType graphql.Output, extensions map[string]int
 		Fields: graphql.Fields{
 			"hero": &graphql.Field{
 				Type: heroType,
-				Resolve: func(params graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(params graphql.ResolveParams) (any, error) {
 					return Hero{
 						Name: "R2-D2",
 						Friends: []Hero{
@@ -2293,7 +2293,7 @@ func TestQuery_ErrorPathForNonNullField(t *testing.T) {
 
 // http://facebook.github.io/graphql/June2018/#example-fce18
 func TestQuery_ErrorExtensions(t *testing.T) {
-	result := testErrors(t, graphql.NewNonNull(graphql.String), map[string]interface{}{
+	result := testErrors(t, graphql.NewNonNull(graphql.String), map[string]any{
 		"code":      "CAN_NOT_FETCH_BY_ID",
 		"timestamp": "Fri Feb 9 14:33:09 UTC 2018",
 	}, nil)
@@ -2343,7 +2343,7 @@ func TestQuery_OriginalErrorBuiltin(t *testing.T) {
 }
 
 func TestQuery_OriginalErrorExtended(t *testing.T) {
-	result := testErrors(t, graphql.String, map[string]interface{}{
+	result := testErrors(t, graphql.String, map[string]any{
 		"code": "CAN_NOT_FETCH_BY_ID",
 	}, nil)
 	switch err := result.Errors[0].OriginalError().(type) {

--- a/executor_test.go
+++ b/executor_test.go
@@ -525,7 +525,7 @@ func TestThreadsContextCorrectly(t *testing.T) {
 				"a": &graphql.Field{
 					Type: graphql.String,
 					Resolve: func(p graphql.ResolveParams) (any, error) {
-						return p.Context.Value("foo"), nil
+						return testutil.ContextValue(p.Context, "foo"), nil
 					},
 				},
 			},
@@ -542,7 +542,7 @@ func TestThreadsContextCorrectly(t *testing.T) {
 	ep := graphql.ExecuteParams{
 		Schema:  schema,
 		AST:     ast,
-		Context: context.WithValue(context.Background(), "foo", "bar"),
+		Context: testutil.ContextWithValue(context.Background(), "foo", "bar"),
 	}
 	result := testutil.TestExecute(t, ep)
 	if len(result.Errors) > 0 {

--- a/executor_test.go
+++ b/executor_test.go
@@ -771,7 +771,7 @@ func TestThrowsIfNoOperationIsProvided(t *testing.T) {
 
 	expectedErrors := []gqlerrors.FormattedError{
 		{
-			Message:   "Must provide an operation.",
+			Message:   "must provide an operation",
 			Locations: []location.SourceLocation{},
 		},
 	}
@@ -816,7 +816,7 @@ func TestThrowsIfNoOperationNameIsProvidedWithMultipleOperations(t *testing.T) {
 
 	expectedErrors := []gqlerrors.FormattedError{
 		{
-			Message:   "Must provide operation name if query contains multiple operations.",
+			Message:   "must provide operation name if query contains multiple operations",
 			Locations: []location.SourceLocation{},
 		},
 	}
@@ -862,7 +862,7 @@ func TestThrowsIfUnknownOperationNameIsProvided(t *testing.T) {
 
 	expectedErrors := []gqlerrors.FormattedError{
 		{
-			Message:   `Unknown operation named "UnknownExample".`,
+			Message:   `unknown operation named "UnknownExample"`,
 			Locations: []location.SourceLocation{},
 		},
 	}

--- a/executor_test.go
+++ b/executor_test.go
@@ -205,7 +205,7 @@ func TestExecutesArbitraryCode(t *testing.T) {
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -292,7 +292,7 @@ func TestMergesParallelFragments(t *testing.T) {
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -507,7 +507,7 @@ func TestThreadsRootValueContextCorrectly(t *testing.T) {
 			"a": "stringValue",
 		},
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -554,7 +554,7 @@ func TestThreadsContextCorrectly(t *testing.T) {
 			"a": "bar",
 		},
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -667,7 +667,7 @@ func TestUsesTheInlineOperationIfNoOperationNameIsProvided(t *testing.T) {
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -712,7 +712,7 @@ func TestUsesTheOnlyOperationIfNoOperationNameIsProvided(t *testing.T) {
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -757,7 +757,7 @@ func TestUsesTheNamedOperationIfOperationNameIsProvided(t *testing.T) {
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1008,7 +1008,7 @@ func TestUsesTheQuerySchemaForQueries(t *testing.T) {
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1063,7 +1063,7 @@ func TestUsesTheMutationSchemaForMutations(t *testing.T) {
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1118,7 +1118,7 @@ func TestUsesTheSubscriptionSchemaForSubscriptions(t *testing.T) {
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1191,7 +1191,7 @@ func TestCorrectFieldOrderingDespiteExecutionOrder(t *testing.T) {
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 
@@ -1258,7 +1258,7 @@ func TestAvoidsRecursion(t *testing.T) {
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 
@@ -1308,7 +1308,7 @@ func TestDoesNotIncludeIllegalFieldsInOutput(t *testing.T) {
 	if len(result.Errors) != 0 {
 		t.Fatalf("wrong result, expected len(%v) errors, got len(%v)", len(expected.Errors), len(result.Errors))
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1370,7 +1370,7 @@ func TestDoesNotIncludeArgumentsThatWereNotSet(t *testing.T) {
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -2105,20 +2105,20 @@ func TestThunkErrorsAreHandledCorrectly(t *testing.T) {
 func assertJSON(t *testing.T, expected string, actual any) {
 	var e any
 	if err := json.Unmarshal([]byte(expected), &e); err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	aJSON, err := json.MarshalIndent(actual, "", "  ")
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	var a any
 	if err := json.Unmarshal(aJSON, &a); err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	if !reflect.DeepEqual(e, a) {
 		eNormalizedJSON, err := json.MarshalIndent(e, "", "  ")
 		if err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 		t.Fatalf("Expected JSON:\n\n%v\n\nActual JSON:\n\n%v", string(eNormalizedJSON), string(aJSON))
 	}

--- a/extensions.go
+++ b/extensions.go
@@ -24,9 +24,9 @@ type (
 	executionFinishFuncHandler func(*Result) []gqlerrors.FormattedError
 
 	// ResolveFieldFinishFunc is called with the result of the ResolveFn and the error it returned
-	ResolveFieldFinishFunc func(interface{}, error)
+	ResolveFieldFinishFunc func(any, error)
 	// resolveFieldFinishFuncHandler calls the resolveFieldFinishFns for all the extensions
-	resolveFieldFinishFuncHandler func(interface{}, error) []gqlerrors.FormattedError
+	resolveFieldFinishFuncHandler func(any, error) []gqlerrors.FormattedError
 )
 
 // Extension is an interface for extensions in graphql
@@ -53,7 +53,7 @@ type Extension interface {
 	HasResult() bool
 
 	// GetResult returns the data that the extension wants to add to the result
-	GetResult(context.Context) interface{}
+	GetResult(context.Context) any
 }
 
 // handleExtensionsInits handles all the init functions for all the extensions in the schema
@@ -213,7 +213,7 @@ func handleExtensionsResolveFieldDidStart(exts []Extension, p *executionContext,
 			fs[ext.Name()] = finishFn
 		}()
 	}
-	return errs, func(val interface{}, err error) []gqlerrors.FormattedError {
+	return errs, func(val any, err error) []gqlerrors.FormattedError {
 		extErrs := gqlerrors.FormattedErrors{}
 		for name, finishFn := range fs {
 			func() {
@@ -241,7 +241,7 @@ func addExtensionResults(p *ExecuteParams, result *Result) {
 				}()
 				if ext.HasResult() {
 					if result.Extensions == nil {
-						result.Extensions = make(map[string]interface{})
+						result.Extensions = make(map[string]any)
 					}
 					result.Extensions[ext.Name()] = ext.GetResult(p.Context)
 				}

--- a/extensions.go
+++ b/extensions.go
@@ -192,7 +192,7 @@ func handleExtensionsExecutionDidStart(p *ExecuteParams) ([]gqlerrors.FormattedE
 }
 
 // handleResolveFieldDidStart handles the notification of the extensions about the start of a resolve function
-func handleExtensionsResolveFieldDidStart(exts []Extension, p *executionContext, i *ResolveInfo) ([]gqlerrors.FormattedError, resolveFieldFinishFuncHandler) {
+func handleExtensionsResolveFieldDidStart(_ []Extension, p *executionContext, i *ResolveInfo) ([]gqlerrors.FormattedError, resolveFieldFinishFuncHandler) {
 	fs := map[string]ResolveFieldFinishFunc{}
 	errs := gqlerrors.FormattedErrors{}
 	for _, ext := range p.Schema.extensions {

--- a/extensions_test.go
+++ b/extensions_test.go
@@ -56,14 +56,14 @@ func TestExtensionInitPanic(t *testing.T) {
 		RequestString: query,
 	})
 
-	expected := &graphql.Result{
-		Data: nil,
-		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(fmt.Errorf("%s.Init: %v", ext.Name(), errors.New("test error"))),
-		},
+	expectedErrors := []gqlerrors.FormattedError{
+		gqlerrors.FormatError(fmt.Errorf("%s.Init: %v", ext.Name(), errors.New("test error"))),
 	}
-	if !reflect.DeepEqual(expected, result) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
+	if result.Data != nil {
+		t.Fatalf("Unexpected result, Data: %v", result)
+	}
+	if !testutil.EqualFormattedErrors(expectedErrors, result.Errors) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expectedErrors, result.Errors))
 	}
 }
 
@@ -87,14 +87,14 @@ func TestExtensionParseDidStartPanic(t *testing.T) {
 		RequestString: query,
 	})
 
-	expected := &graphql.Result{
-		Data: nil,
-		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(fmt.Errorf("%s.ParseDidStart: %v", ext.Name(), errors.New("test error"))),
-		},
+	if result.Data != nil {
+		t.Fatalf("Unexpected result, Data: %v", result)
 	}
-	if !reflect.DeepEqual(expected, result) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
+	expectedErrors := []gqlerrors.FormattedError{
+		gqlerrors.FormatError(fmt.Errorf("%s.ParseDidStart: %v", ext.Name(), errors.New("test error"))),
+	}
+	if !testutil.EqualFormattedErrors(expectedErrors, result.Errors) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expectedErrors, result.Errors))
 	}
 }
 
@@ -115,14 +115,14 @@ func TestExtensionParseFinishFuncPanic(t *testing.T) {
 		RequestString: query,
 	})
 
-	expected := &graphql.Result{
-		Data: nil,
-		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(fmt.Errorf("%s.ParseFinishFunc: %v", ext.Name(), errors.New("test error"))),
-		},
+	if result.Data != nil {
+		t.Fatalf("Unexpected result, Data: %v", result)
 	}
-	if !reflect.DeepEqual(expected, result) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
+	expectedErrors := []gqlerrors.FormattedError{
+		gqlerrors.FormatError(fmt.Errorf("%s.ParseFinishFunc: %v", ext.Name(), errors.New("test error"))),
+	}
+	if !testutil.EqualFormattedErrors(expectedErrors, result.Errors) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expectedErrors, result.Errors))
 	}
 }
 
@@ -146,14 +146,14 @@ func TestExtensionValidationDidStartPanic(t *testing.T) {
 		RequestString: query,
 	})
 
-	expected := &graphql.Result{
-		Data: nil,
-		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(fmt.Errorf("%s.ValidationDidStart: %v", ext.Name(), errors.New("test error"))),
-		},
+	if result.Data != nil {
+		t.Fatalf("Unexpected result, Data: %v", result)
 	}
-	if !reflect.DeepEqual(expected, result) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
+	expectedErrors := []gqlerrors.FormattedError{
+		gqlerrors.FormatError(fmt.Errorf("%s.ValidationDidStart: %v", ext.Name(), errors.New("test error"))),
+	}
+	if !testutil.EqualFormattedErrors(expectedErrors, result.Errors) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expectedErrors, result.Errors))
 	}
 }
 
@@ -174,14 +174,14 @@ func TestExtensionValidationFinishFuncPanic(t *testing.T) {
 		RequestString: query,
 	})
 
-	expected := &graphql.Result{
-		Data: nil,
-		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(fmt.Errorf("%s.ValidationFinishFunc: %v", ext.Name(), errors.New("test error"))),
-		},
+	if result.Data != nil {
+		t.Fatalf("Unexpected result, Data: %v", result)
 	}
-	if !reflect.DeepEqual(expected, result) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
+	expectedErrors := []gqlerrors.FormattedError{
+		gqlerrors.FormatError(fmt.Errorf("%s.ValidationFinishFunc: %v", ext.Name(), errors.New("test error"))),
+	}
+	if !testutil.EqualFormattedErrors(expectedErrors, result.Errors) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expectedErrors, result.Errors))
 	}
 }
 
@@ -205,14 +205,14 @@ func TestExtensionExecutionDidStartPanic(t *testing.T) {
 		RequestString: query,
 	})
 
-	expected := &graphql.Result{
-		Data: nil,
-		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(fmt.Errorf("%s.ExecutionDidStart: %v", ext.Name(), errors.New("test error"))),
-		},
+	if result.Data != nil {
+		t.Fatalf("Unexpected result, Data: %v", result)
 	}
-	if !reflect.DeepEqual(expected, result) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
+	expectedErrors := []gqlerrors.FormattedError{
+		gqlerrors.FormatError(fmt.Errorf("%s.ExecutionDidStart: %v", ext.Name(), errors.New("test error"))),
+	}
+	if !testutil.EqualFormattedErrors(expectedErrors, result.Errors) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expectedErrors, result.Errors))
 	}
 }
 
@@ -242,8 +242,11 @@ func TestExtensionExecutionFinishFuncPanic(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(expected, result) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
+	if !reflect.DeepEqual(expected.Data, result.Data) {
+		t.Fatalf("Expected data: %v, got: %v", expected.Data, result.Data)
+	}
+	if !testutil.EqualFormattedErrors(expected.Errors, result.Errors) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
 }
 
@@ -275,9 +278,11 @@ func TestExtensionResolveFieldDidStartPanic(t *testing.T) {
 			gqlerrors.FormatError(fmt.Errorf("%s.ResolveFieldDidStart: %v", ext.Name(), errors.New("test error"))),
 		},
 	}
-
-	if !reflect.DeepEqual(expected, result) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
+	if !reflect.DeepEqual(expected.Data, result.Data) {
+		t.Fatalf("Expected data: %v, got: %v", expected.Data, result.Data)
+	}
+	if !testutil.EqualFormattedErrors(expected.Errors, result.Errors) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
 }
 
@@ -306,9 +311,11 @@ func TestExtensionResolveFieldFinishFuncPanic(t *testing.T) {
 			gqlerrors.FormatError(fmt.Errorf("%s.ResolveFieldFinishFunc: %v", ext.Name(), errors.New("test error"))),
 		},
 	}
-
-	if !reflect.DeepEqual(expected, result) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
+	if !reflect.DeepEqual(expected.Data, result.Data) {
+		t.Fatalf("Expected data: %v, got: %v", expected.Data, result.Data)
+	}
+	if !testutil.EqualFormattedErrors(expected.Errors, result.Errors) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
 }
 
@@ -372,8 +379,14 @@ func TestExtensionGetResultPanic(t *testing.T) {
 		Extensions: make(map[string]any),
 	}
 
-	if !reflect.DeepEqual(expected, result) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
+	if !reflect.DeepEqual(expected.Data, result.Data) {
+		t.Fatalf("Expected data: %v, got: %v", expected.Data, result.Data)
+	}
+	if !testutil.EqualFormattedErrors(expected.Errors, result.Errors) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
+	}
+	if !reflect.DeepEqual(expected.Extensions, result.Extensions) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Extensions, result.Extensions))
 	}
 }
 

--- a/extensions_test.go
+++ b/extensions_test.go
@@ -19,13 +19,13 @@ func tinit(t *testing.T) graphql.Schema {
 			Fields: graphql.Fields{
 				"a": &graphql.Field{
 					Type: graphql.String,
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(p graphql.ResolveParams) (any, error) {
 						return "foo", nil
 					},
 				},
 				"erred": &graphql.Field{
 					Type: graphql.String,
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(p graphql.ResolveParams) (any, error) {
 						return "", errors.New("ooops")
 					},
 				},
@@ -234,7 +234,7 @@ func TestExtensionExecutionFinishFuncPanic(t *testing.T) {
 	})
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "foo",
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -253,7 +253,7 @@ func TestExtensionResolveFieldDidStartPanic(t *testing.T) {
 		if true {
 			panic(errors.New("test error"))
 		}
-		return ctx, func(v interface{}, err error) {
+		return ctx, func(v any, err error) {
 
 		}
 	}
@@ -268,7 +268,7 @@ func TestExtensionResolveFieldDidStartPanic(t *testing.T) {
 	})
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "foo",
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -284,7 +284,7 @@ func TestExtensionResolveFieldDidStartPanic(t *testing.T) {
 func TestExtensionResolveFieldFinishFuncPanic(t *testing.T) {
 	ext := newtestExt("testExt")
 	ext.resolveFieldDidStartFn = func(ctx context.Context, i *graphql.ResolveInfo) (context.Context, graphql.ResolveFieldFinishFunc) {
-		return ctx, func(v interface{}, err error) {
+		return ctx, func(v any, err error) {
 			panic(errors.New("test error"))
 		}
 	}
@@ -299,7 +299,7 @@ func TestExtensionResolveFieldFinishFuncPanic(t *testing.T) {
 	})
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "foo",
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -316,7 +316,7 @@ func TestExtensionResolveFieldFinishFuncAfterError(t *testing.T) {
 	var fnErrs int
 	ext := newtestExt("testExt")
 	ext.resolveFieldDidStartFn = func(ctx context.Context, i *graphql.ResolveInfo) (context.Context, graphql.ResolveFieldFinishFunc) {
-		return ctx, func(v interface{}, err error) {
+		return ctx, func(v any, err error) {
 			if err != nil {
 				fnErrs++
 			}
@@ -343,7 +343,7 @@ func TestExtensionResolveFieldFinishFuncAfterError(t *testing.T) {
 
 func TestExtensionGetResultPanic(t *testing.T) {
 	ext := newtestExt("testExt")
-	ext.getResultFn = func(context.Context) interface{} {
+	ext.getResultFn = func(context.Context) any {
 		if true {
 			panic(errors.New("test error"))
 		}
@@ -363,13 +363,13 @@ func TestExtensionGetResultPanic(t *testing.T) {
 	})
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"a": "foo",
 		},
 		Errors: []gqlerrors.FormattedError{
 			gqlerrors.FormatError(fmt.Errorf("%s.GetResult: %v", ext.Name(), errors.New("test error"))),
 		},
-		Extensions: make(map[string]interface{}),
+		Extensions: make(map[string]any),
 	}
 
 	if !reflect.DeepEqual(expected, result) {
@@ -409,7 +409,7 @@ func newtestExt(name string) *testExt {
 	}
 	if ext.resolveFieldDidStartFn == nil {
 		ext.resolveFieldDidStartFn = func(ctx context.Context, i *graphql.ResolveInfo) (context.Context, graphql.ResolveFieldFinishFunc) {
-			return ctx, func(v interface{}, err error) {
+			return ctx, func(v any, err error) {
 
 			}
 		}
@@ -420,7 +420,7 @@ func newtestExt(name string) *testExt {
 		}
 	}
 	if ext.getResultFn == nil {
-		ext.getResultFn = func(context.Context) interface{} {
+		ext.getResultFn = func(context.Context) any {
 			return nil
 		}
 	}
@@ -431,7 +431,7 @@ type testExt struct {
 	name                   string
 	initFn                 func(ctx context.Context, p *graphql.Params) context.Context
 	hasResultFn            func() bool
-	getResultFn            func(context.Context) interface{}
+	getResultFn            func(context.Context) any
 	parseDidStartFn        func(ctx context.Context) (context.Context, graphql.ParseFinishFunc)
 	validationDidStartFn   func(ctx context.Context) (context.Context, graphql.ValidationFinishFunc)
 	executionDidStartFn    func(ctx context.Context) (context.Context, graphql.ExecutionFinishFunc)
@@ -450,7 +450,7 @@ func (t *testExt) HasResult() bool {
 	return t.hasResultFn()
 }
 
-func (t *testExt) GetResult(ctx context.Context) interface{} {
+func (t *testExt) GetResult(ctx context.Context) any {
 	return t.getResultFn(ctx)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/machship/graphql
 
-go 1.13
+go 1.23

--- a/gqlerrors/error.go
+++ b/gqlerrors/error.go
@@ -17,7 +17,7 @@ type Error struct {
 	Positions     []int
 	Locations     []location.SourceLocation
 	OriginalError error
-	Path          []interface{}
+	Path          []any
 }
 
 // implements Golang's built-in `error` interface
@@ -29,11 +29,11 @@ func NewError(message string, nodes []ast.Node, stack string, source *source.Sou
 	return newError(message, nodes, stack, source, positions, nil, origError)
 }
 
-func NewErrorWithPath(message string, nodes []ast.Node, stack string, source *source.Source, positions []int, path []interface{}, origError error) *Error {
+func NewErrorWithPath(message string, nodes []ast.Node, stack string, source *source.Source, positions []int, path []any, origError error) *Error {
 	return newError(message, nodes, stack, source, positions, path, origError)
 }
 
-func newError(message string, nodes []ast.Node, stack string, source *source.Source, positions []int, path []interface{}, origError error) *Error {
+func newError(message string, nodes []ast.Node, stack string, source *source.Source, positions []int, path []any, origError error) *Error {
 	if stack == "" && message != "" {
 		stack = message
 	}

--- a/gqlerrors/formatted.go
+++ b/gqlerrors/formatted.go
@@ -8,14 +8,14 @@ import (
 
 type ExtendedError interface {
 	error
-	Extensions() map[string]interface{}
+	Extensions() map[string]any
 }
 
 type FormattedError struct {
 	Message       string                    `json:"message"`
 	Locations     []location.SourceLocation `json:"locations"`
-	Path          []interface{}             `json:"path,omitempty"`
-	Extensions    map[string]interface{}    `json:"extensions,omitempty"`
+	Path          []any                     `json:"path,omitempty"`
+	Extensions    map[string]any            `json:"extensions,omitempty"`
 	originalError error
 }
 

--- a/gqlerrors/located.go
+++ b/gqlerrors/located.go
@@ -2,13 +2,14 @@ package gqlerrors
 
 import (
 	"errors"
+
 	"github.com/machship/graphql/language/ast"
 )
 
 // NewLocatedError creates a graphql.Error with location info
 // @deprecated 0.4.18
 // Already exists in `graphql.NewLocatedError()`
-func NewLocatedError(err interface{}, nodes []ast.Node) *Error {
+func NewLocatedError(err any, nodes []ast.Node) *Error {
 	var origError error
 	message := "An unknown error occurred."
 	if err, ok := err.(error); ok {

--- a/gqlerrors/syntax.go
+++ b/gqlerrors/syntax.go
@@ -36,7 +36,7 @@ func printLine(str string) string {
 	for _, runeValue := range str {
 		strSlice = append(strSlice, printCharCode(runeValue))
 	}
-	return fmt.Sprintf(`%s`, strings.Join(strSlice, ""))
+	return strings.Join(strSlice, "")
 }
 func highlightSourceAtLocation(s *source.Source, l location.SourceLocation) string {
 	line := l.Line

--- a/graphql.go
+++ b/graphql.go
@@ -17,11 +17,11 @@ type Params struct {
 
 	// The value provided as the first argument to resolver functions on the top
 	// level type (e.g. the query object type).
-	RootObject map[string]interface{}
+	RootObject map[string]any
 
 	// A mapping of variable name to runtime value to use for all variables
 	// defined in the requestString.
-	VariableValues map[string]interface{}
+	VariableValues map[string]any
 
 	// The name of the operation to use if requestString contains multiple
 	// possible operations. Can be omitted if requestString contains only

--- a/graphql_bench_test.go
+++ b/graphql_bench_test.go
@@ -7,12 +7,7 @@ import (
 	"github.com/machship/graphql/benchutil"
 )
 
-type B struct {
-	Query  string
-	Schema graphql.Schema
-}
-
-func benchGraphql(bench B, p graphql.Params, t testing.TB) {
+func benchGraphql(p graphql.Params, t testing.TB) {
 	result := graphql.Do(p)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
@@ -43,28 +38,24 @@ func BenchmarkListQuery_100K(b *testing.B) {
 func nItemsListQueryBenchmark(x int) func(b *testing.B) {
 	return func(b *testing.B) {
 		schema := benchutil.ListSchemaWithXItems(x)
-
-		bench := B{
-			Query: `
-				query {
-					colors {
-						hex
-						r
-						g
-						b
-					}
+		query := `
+			query {
+				colors {
+					hex
+					r
+					g
+					b
 				}
-			`,
-			Schema: schema,
-		}
+			}
+		`
 
 		for i := 0; i < b.N; i++ {
 
 			params := graphql.Params{
 				Schema:        schema,
-				RequestString: bench.Query,
+				RequestString: query,
 			}
-			benchGraphql(bench, params, b)
+			benchGraphql(params, b)
 		}
 	}
 }
@@ -106,19 +97,14 @@ func nFieldsyItemsQueryBenchmark(x int, y int) func(b *testing.B) {
 		schema := benchutil.WideSchemaWithXFieldsAndYItems(x, y)
 		query := benchutil.WideSchemaQuery(x)
 
-		bench := B{
-			Query:  query,
-			Schema: schema,
-		}
-
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
 			params := graphql.Params{
 				Schema:        schema,
-				RequestString: bench.Query,
+				RequestString: query,
 			}
-			benchGraphql(bench, params, b)
+			benchGraphql(params, b)
 		}
 	}
 }

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 type T struct {
+	name      string
 	Query     string
 	Schema    graphql.Schema
 	Expected  any
@@ -38,6 +39,7 @@ func init() {
 			},
 		},
 		{
+			name: "xyz",
 			Query: `
 				query HeroNameAndFriendsQuery {
 					hero {

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -156,7 +156,7 @@ func TestBasicGraphQLExample(t *testing.T) {
 
 func TestThreadsContextFromParamsThrough(t *testing.T) {
 	extractFieldFromContextFn := func(p graphql.ResolveParams) (any, error) {
-		return p.Context.Value(p.Args["key"]), nil
+		return testutil.ContextValue(p.Context, p.Args["key"].(string)), nil
 	}
 
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
@@ -181,7 +181,7 @@ func TestThreadsContextFromParamsThrough(t *testing.T) {
 	result := graphql.Do(graphql.Params{
 		Schema:        schema,
 		RequestString: query,
-		Context:       context.WithValue(context.TODO(), "a", "xyz"),
+		Context:       testutil.ContextWithValue(context.Background(), "a", "xyz"),
 	})
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -12,8 +12,8 @@ import (
 type T struct {
 	Query     string
 	Schema    graphql.Schema
-	Expected  interface{}
-	Variables map[string]interface{}
+	Expected  any
+	Variables map[string]any
 }
 
 var Tests = []T{}
@@ -30,8 +30,8 @@ func init() {
 			`,
 			Schema: testutil.StarWarsSchema,
 			Expected: &graphql.Result{
-				Data: map[string]interface{}{
-					"hero": map[string]interface{}{
+				Data: map[string]any{
+					"hero": map[string]any{
 						"name": "R2-D2",
 					},
 				},
@@ -51,18 +51,18 @@ func init() {
 			`,
 			Schema: testutil.StarWarsSchema,
 			Expected: &graphql.Result{
-				Data: map[string]interface{}{
-					"hero": map[string]interface{}{
+				Data: map[string]any{
+					"hero": map[string]any{
 						"id":   "2001",
 						"name": "R2-D2",
-						"friends": []interface{}{
-							map[string]interface{}{
+						"friends": []any{
+							map[string]any{
 								"name": "Luke Skywalker",
 							},
-							map[string]interface{}{
+							map[string]any{
 								"name": "Han Solo",
 							},
-							map[string]interface{}{
+							map[string]any{
 								"name": "Leia Organa",
 							},
 						},
@@ -80,13 +80,13 @@ func init() {
 			`,
 			Schema: testutil.StarWarsSchema,
 			Expected: &graphql.Result{
-				Data: map[string]interface{}{
-					"human": map[string]interface{}{
+				Data: map[string]any{
+					"human": map[string]any{
 						"name": "Darth Vader",
 					},
 				},
 			},
-			Variables: map[string]interface{}{
+			Variables: map[string]any{
 				"id": "1001",
 			},
 		},
@@ -117,7 +117,7 @@ func testGraphql(test T, p graphql.Params, t *testing.T) {
 func TestBasicGraphQLExample(t *testing.T) {
 	// taken from `graphql-js` README
 
-	helloFieldResolved := func(p graphql.ResolveParams) (interface{}, error) {
+	helloFieldResolved := func(p graphql.ResolveParams) (any, error) {
 		return "world", nil
 	}
 
@@ -137,8 +137,8 @@ func TestBasicGraphQLExample(t *testing.T) {
 		t.Fatalf("wrong result, unexpected errors: %v", err.Error())
 	}
 	query := "{ hello }"
-	var expected interface{}
-	expected = map[string]interface{}{
+	var expected any
+	expected = map[string]any{
 		"hello": "world",
 	}
 
@@ -156,7 +156,7 @@ func TestBasicGraphQLExample(t *testing.T) {
 }
 
 func TestThreadsContextFromParamsThrough(t *testing.T) {
-	extractFieldFromContextFn := func(p graphql.ResolveParams) (interface{}, error) {
+	extractFieldFromContextFn := func(p graphql.ResolveParams) (any, error) {
 		return p.Context.Value(p.Args["key"]), nil
 	}
 
@@ -187,7 +187,7 @@ func TestThreadsContextFromParamsThrough(t *testing.T) {
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	expected := map[string]interface{}{"value": "xyz"}
+	expected := map[string]any{"value": "xyz"}
 	if !reflect.DeepEqual(result.Data, expected) {
 		t.Fatalf("wrong result, query: %v, graphql result diff: %v", query, testutil.Diff(expected, result))
 	}
@@ -201,7 +201,7 @@ func TestNewErrorChecksNilNodes(t *testing.T) {
 			Fields: graphql.Fields{
 				"graphql_is": &graphql.Field{
 					Type: graphql.String,
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(p graphql.ResolveParams) (any, error) {
 						return "", nil
 					},
 				},
@@ -222,14 +222,14 @@ func TestNewErrorChecksNilNodes(t *testing.T) {
 }
 
 func TestEmptyStringIsNotNull(t *testing.T) {
-	checkForEmptyString := func(p graphql.ResolveParams) (interface{}, error) {
+	checkForEmptyString := func(p graphql.ResolveParams) (any, error) {
 		arg := p.Args["arg"]
 		if arg == nil || arg.(string) != "" {
 			t.Errorf("Expected empty string for input arg, got %#v", arg)
 		}
 		return "yay", nil
 	}
-	returnEmptyString := func(p graphql.ResolveParams) (interface{}, error) {
+	returnEmptyString := func(p graphql.ResolveParams) (any, error) {
 		return "", nil
 	}
 
@@ -263,7 +263,7 @@ func TestEmptyStringIsNotNull(t *testing.T) {
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	expected := map[string]interface{}{"checkEmptyArg": "yay", "checkEmptyResult": ""}
+	expected := map[string]any{"checkEmptyArg": "yay", "checkEmptyResult": ""}
 	if !reflect.DeepEqual(result.Data, expected) {
 		t.Errorf("wrong result, query: %v, graphql result diff: %v", query, testutil.Diff(expected, result))
 	}

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -137,8 +137,7 @@ func TestBasicGraphQLExample(t *testing.T) {
 		t.Fatalf("wrong result, unexpected errors: %v", err.Error())
 	}
 	query := "{ hello }"
-	var expected any
-	expected = map[string]any{
+	var expected any = map[string]any{
 		"hello": "world",
 	}
 

--- a/introspection.go
+++ b/introspection.go
@@ -217,7 +217,7 @@ func init() {
 					case *NonNull:
 						return TypeKindNonNull, nil
 					}
-					return nil, fmt.Errorf("Unknown kind of type: %v", p.Source)
+					return nil, fmt.Errorf("unknown kind of type: %v", p.Source)
 				},
 			},
 			"name": &Field{

--- a/introspection.go
+++ b/introspection.go
@@ -198,7 +198,7 @@ func init() {
 		Fields: Fields{
 			"kind": &Field{
 				Type: NewNonNull(TypeKindEnumType),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(p ResolveParams) (any, error) {
 					switch p.Source.(type) {
 					case *Scalar:
 						return TypeKindScalar, nil
@@ -254,7 +254,7 @@ func init() {
 				Type: String,
 				Description: "A GraphQL-formatted string representing the default value for this " +
 					"input value.",
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(p ResolveParams) (any, error) {
 					if inputVal, ok := p.Source.(*Argument); ok {
 						if inputVal.DefaultValue == nil {
 							return nil, nil
@@ -291,11 +291,11 @@ func init() {
 			},
 			"args": &Field{
 				Type: NewNonNull(NewList(NewNonNull(InputValueType))),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(p ResolveParams) (any, error) {
 					if field, ok := p.Source.(*FieldDefinition); ok {
 						return field.Args, nil
 					}
-					return []interface{}{}, nil
+					return []any{}, nil
 				},
 			},
 			"type": &Field{
@@ -303,7 +303,7 @@ func init() {
 			},
 			"isDeprecated": &Field{
 				Type: NewNonNull(Boolean),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(p ResolveParams) (any, error) {
 					if field, ok := p.Source.(*FieldDefinition); ok {
 						return (field.DeprecationReason != ""), nil
 					}
@@ -312,7 +312,7 @@ func init() {
 			},
 			"deprecationReason": &Field{
 				Type: String,
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(p ResolveParams) (any, error) {
 					if field, ok := p.Source.(*FieldDefinition); ok {
 						if field.DeprecationReason != "" {
 							return field.DeprecationReason, nil
@@ -354,7 +354,7 @@ func init() {
 			"onOperation": &Field{
 				DeprecationReason: "Use `locations`.",
 				Type:              NewNonNull(Boolean),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(p ResolveParams) (any, error) {
 					if dir, ok := p.Source.(*Directive); ok {
 						res := false
 						for _, loc := range dir.Locations {
@@ -373,7 +373,7 @@ func init() {
 			"onFragment": &Field{
 				DeprecationReason: "Use `locations`.",
 				Type:              NewNonNull(Boolean),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(p ResolveParams) (any, error) {
 					if dir, ok := p.Source.(*Directive); ok {
 						res := false
 						for _, loc := range dir.Locations {
@@ -392,7 +392,7 @@ func init() {
 			"onField": &Field{
 				DeprecationReason: "Use `locations`.",
 				Type:              NewNonNull(Boolean),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(p ResolveParams) (any, error) {
 					if dir, ok := p.Source.(*Directive); ok {
 						res := false
 						for _, loc := range dir.Locations {
@@ -420,7 +420,7 @@ func init() {
 				Type: NewNonNull(NewList(
 					NewNonNull(TypeType),
 				)),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(p ResolveParams) (any, error) {
 					if schema, ok := p.Source.(Schema); ok {
 						results := []Type{}
 						for _, ttype := range schema.TypeMap() {
@@ -434,7 +434,7 @@ func init() {
 			"queryType": &Field{
 				Description: "The type that query operations will be rooted at.",
 				Type:        NewNonNull(TypeType),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(p ResolveParams) (any, error) {
 					if schema, ok := p.Source.(Schema); ok {
 						return schema.QueryType(), nil
 					}
@@ -445,7 +445,7 @@ func init() {
 				Description: `If this server supports mutation, the type that ` +
 					`mutation operations will be rooted at.`,
 				Type: TypeType,
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(p ResolveParams) (any, error) {
 					if schema, ok := p.Source.(Schema); ok {
 						if schema.MutationType() != nil {
 							return schema.MutationType(), nil
@@ -458,7 +458,7 @@ func init() {
 				Description: `If this server supports subscription, the type that ` +
 					`subscription operations will be rooted at.`,
 				Type: TypeType,
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(p ResolveParams) (any, error) {
 					if schema, ok := p.Source.(Schema); ok {
 						if schema.SubscriptionType() != nil {
 							return schema.SubscriptionType(), nil
@@ -472,7 +472,7 @@ func init() {
 				Type: NewNonNull(NewList(
 					NewNonNull(DirectiveType),
 				)),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(p ResolveParams) (any, error) {
 					if schema, ok := p.Source.(Schema); ok {
 						return schema.Directives(), nil
 					}
@@ -496,7 +496,7 @@ func init() {
 			},
 			"isDeprecated": &Field{
 				Type: NewNonNull(Boolean),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(p ResolveParams) (any, error) {
 					if field, ok := p.Source.(*EnumValueDefinition); ok {
 						return (field.DeprecationReason != ""), nil
 					}
@@ -505,7 +505,7 @@ func init() {
 			},
 			"deprecationReason": &Field{
 				Type: String,
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(p ResolveParams) (any, error) {
 					if field, ok := p.Source.(*EnumValueDefinition); ok {
 						if field.DeprecationReason != "" {
 							return field.DeprecationReason, nil
@@ -527,7 +527,7 @@ func init() {
 				DefaultValue: false,
 			},
 		},
-		Resolve: func(p ResolveParams) (interface{}, error) {
+		Resolve: func(p ResolveParams) (any, error) {
 			includeDeprecated, _ := p.Args["includeDeprecated"].(bool)
 			switch ttype := p.Source.(type) {
 			case *Object:
@@ -565,7 +565,7 @@ func init() {
 	})
 	TypeType.AddFieldConfig("interfaces", &Field{
 		Type: NewList(NewNonNull(TypeType)),
-		Resolve: func(p ResolveParams) (interface{}, error) {
+		Resolve: func(p ResolveParams) (any, error) {
 			if ttype, ok := p.Source.(*Object); ok {
 				return ttype.Interfaces(), nil
 			}
@@ -574,7 +574,7 @@ func init() {
 	})
 	TypeType.AddFieldConfig("possibleTypes", &Field{
 		Type: NewList(NewNonNull(TypeType)),
-		Resolve: func(p ResolveParams) (interface{}, error) {
+		Resolve: func(p ResolveParams) (any, error) {
 			switch ttype := p.Source.(type) {
 			case *Interface:
 				return p.Info.Schema.PossibleTypes(ttype), nil
@@ -592,7 +592,7 @@ func init() {
 				DefaultValue: false,
 			},
 		},
-		Resolve: func(p ResolveParams) (interface{}, error) {
+		Resolve: func(p ResolveParams) (any, error) {
 			includeDeprecated, _ := p.Args["includeDeprecated"].(bool)
 			if ttype, ok := p.Source.(*Enum); ok {
 				if includeDeprecated {
@@ -612,7 +612,7 @@ func init() {
 	})
 	TypeType.AddFieldConfig("inputFields", &Field{
 		Type: NewList(NewNonNull(InputValueType)),
-		Resolve: func(p ResolveParams) (interface{}, error) {
+		Resolve: func(p ResolveParams) (any, error) {
 			if ttype, ok := p.Source.(*InputObject); ok {
 				fields := []*InputObjectField{}
 				for _, field := range ttype.Fields() {
@@ -641,7 +641,7 @@ func init() {
 		Type:        NewNonNull(SchemaType),
 		Description: "Access the current type schema of this server.",
 		Args:        []*Argument{},
-		Resolve: func(p ResolveParams) (interface{}, error) {
+		Resolve: func(p ResolveParams) (any, error) {
 			return p.Info.Schema, nil
 		},
 	}
@@ -655,7 +655,7 @@ func init() {
 				Type:        NewNonNull(String),
 			},
 		},
-		Resolve: func(p ResolveParams) (interface{}, error) {
+		Resolve: func(p ResolveParams) (any, error) {
 			name, ok := p.Args["name"].(string)
 			if !ok {
 				return nil, nil
@@ -669,7 +669,7 @@ func init() {
 		Type:        NewNonNull(String),
 		Description: "The name of the current Object type at runtime.",
 		Args:        []*Argument{},
-		Resolve: func(p ResolveParams) (interface{}, error) {
+		Resolve: func(p ResolveParams) (any, error) {
 			return p.Info.ParentType.Name(), nil
 		},
 	}
@@ -689,7 +689,7 @@ func init() {
 // | String        | String / Enum Value  |
 // | Number        | Int / Float          |
 
-func astFromValue(value interface{}, ttype Type) ast.Value {
+func astFromValue(value any, ttype Type) ast.Value {
 
 	if ttype, ok := ttype.(*NonNull); ok {
 		// Note: we're not checking that the result is non-null.

--- a/introspection_test.go
+++ b/introspection_test.go
@@ -27,39 +27,39 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating Schema: %v", err.Error())
 	}
-	expectedDataSubSet := map[string]interface{}{
-		"__schema": map[string]interface{}{
+	expectedDataSubSet := map[string]any{
+		"__schema": map[string]any{
 			"mutationType":     nil,
 			"subscriptionType": nil,
-			"queryType": map[string]interface{}{
+			"queryType": map[string]any{
 				"name": "QueryRoot",
 			},
-			"types": []interface{}{
-				map[string]interface{}{
+			"types": []any{
+				map[string]any{
 					"kind":          "OBJECT",
 					"name":          "QueryRoot",
 					"inputFields":   nil,
-					"interfaces":    []interface{}{},
+					"interfaces":    []any{},
 					"enumValues":    nil,
 					"possibleTypes": nil,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"kind": "OBJECT",
 					"name": "__Schema",
-					"fields": []interface{}{
-						map[string]interface{}{
+					"fields": []any{
+						map[string]any{
 							"name": "types",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind": "LIST",
 									"name": nil,
-									"ofType": map[string]interface{}{
+									"ofType": map[string]any{
 										"kind": "NON_NULL",
 										"name": nil,
-										"ofType": map[string]interface{}{
+										"ofType": map[string]any{
 											"kind": "OBJECT",
 											"name": "__Type",
 										},
@@ -69,13 +69,13 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "queryType",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind": "OBJECT",
 									"name": "__Type",
 								},
@@ -83,39 +83,39 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "mutationType",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "OBJECT",
 								"name": "__Type",
 							},
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "subscriptionType",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "OBJECT",
 								"name": "__Type",
 							},
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "directives",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind": "LIST",
 									"name": nil,
-									"ofType": map[string]interface{}{
+									"ofType": map[string]any{
 										"kind": "NON_NULL",
 										"name": nil,
-										"ofType": map[string]interface{}{
+										"ofType": map[string]any{
 											"kind": "OBJECT",
 											"name": "__Directive",
 										},
@@ -127,21 +127,21 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 						},
 					},
 					"inputFields":   nil,
-					"interfaces":    []interface{}{},
+					"interfaces":    []any{},
 					"enumValues":    nil,
 					"possibleTypes": nil,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"kind": "OBJECT",
 					"name": "__Type",
-					"fields": []interface{}{
-						map[string]interface{}{
+					"fields": []any{
+						map[string]any{
 							"name": "kind",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind":   "ENUM",
 									"name":   "__TypeKind",
 									"ofType": nil,
@@ -150,10 +150,10 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "name",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind":   "SCALAR",
 								"name":   "String",
 								"ofType": nil,
@@ -161,10 +161,10 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "description",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind":   "SCALAR",
 								"name":   "String",
 								"ofType": nil,
@@ -172,12 +172,12 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "fields",
-							"args": []interface{}{
-								map[string]interface{}{
+							"args": []any{
+								map[string]any{
 									"name": "includeDeprecated",
-									"type": map[string]interface{}{
+									"type": map[string]any{
 										"kind":   "SCALAR",
 										"name":   "Boolean",
 										"ofType": nil,
@@ -185,13 +185,13 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 									"defaultValue": "false",
 								},
 							},
-							"type": map[string]interface{}{
+							"type": map[string]any{
 								"kind": "LIST",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind": "NON_NULL",
 									"name": nil,
-									"ofType": map[string]interface{}{
+									"ofType": map[string]any{
 										"kind":   "OBJECT",
 										"name":   "__Field",
 										"ofType": nil,
@@ -201,16 +201,16 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "interfaces",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "LIST",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind": "NON_NULL",
 									"name": nil,
-									"ofType": map[string]interface{}{
+									"ofType": map[string]any{
 										"kind":   "OBJECT",
 										"name":   "__Type",
 										"ofType": nil,
@@ -220,16 +220,16 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "possibleTypes",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "LIST",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind": "NON_NULL",
 									"name": nil,
-									"ofType": map[string]interface{}{
+									"ofType": map[string]any{
 										"kind":   "OBJECT",
 										"name":   "__Type",
 										"ofType": nil,
@@ -239,12 +239,12 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "enumValues",
-							"args": []interface{}{
-								map[string]interface{}{
+							"args": []any{
+								map[string]any{
 									"name": "includeDeprecated",
-									"type": map[string]interface{}{
+									"type": map[string]any{
 										"kind":   "SCALAR",
 										"name":   "Boolean",
 										"ofType": nil,
@@ -252,13 +252,13 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 									"defaultValue": "false",
 								},
 							},
-							"type": map[string]interface{}{
+							"type": map[string]any{
 								"kind": "LIST",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind": "NON_NULL",
 									"name": nil,
-									"ofType": map[string]interface{}{
+									"ofType": map[string]any{
 										"kind":   "OBJECT",
 										"name":   "__EnumValue",
 										"ofType": nil,
@@ -268,16 +268,16 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "inputFields",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "LIST",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind": "NON_NULL",
 									"name": nil,
-									"ofType": map[string]interface{}{
+									"ofType": map[string]any{
 										"kind":   "OBJECT",
 										"name":   "__InputValue",
 										"ofType": nil,
@@ -287,10 +287,10 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "ofType",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind":   "OBJECT",
 								"name":   "__Type",
 								"ofType": nil,
@@ -300,53 +300,53 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 						},
 					},
 					"inputFields":   nil,
-					"interfaces":    []interface{}{},
+					"interfaces":    []any{},
 					"enumValues":    nil,
 					"possibleTypes": nil,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"kind":        "ENUM",
 					"name":        "__TypeKind",
 					"fields":      nil,
 					"inputFields": nil,
 					"interfaces":  nil,
-					"enumValues": []interface{}{
-						map[string]interface{}{
+					"enumValues": []any{
+						map[string]any{
 							"name":              "SCALAR",
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name":              "OBJECT",
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name":              "INTERFACE",
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name":              "UNION",
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name":              "ENUM",
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name":              "INPUT_OBJECT",
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name":              "LIST",
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name":              "NON_NULL",
 							"isDeprecated":      false,
 							"deprecationReason": nil,
@@ -354,7 +354,7 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 					},
 					"possibleTypes": nil,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"kind":          "SCALAR",
 					"name":          "String",
 					"fields":        nil,
@@ -363,7 +363,7 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 					"enumValues":    nil,
 					"possibleTypes": nil,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"kind":          "SCALAR",
 					"name":          "Boolean",
 					"fields":        nil,
@@ -372,17 +372,17 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 					"enumValues":    nil,
 					"possibleTypes": nil,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"kind": "OBJECT",
 					"name": "__Field",
-					"fields": []interface{}{
-						map[string]interface{}{
+					"fields": []any{
+						map[string]any{
 							"name": "name",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind":   "SCALAR",
 									"name":   "String",
 									"ofType": nil,
@@ -391,10 +391,10 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "description",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind":   "SCALAR",
 								"name":   "String",
 								"ofType": nil,
@@ -402,19 +402,19 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "args",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind": "LIST",
 									"name": nil,
-									"ofType": map[string]interface{}{
+									"ofType": map[string]any{
 										"kind": "NON_NULL",
 										"name": nil,
-										"ofType": map[string]interface{}{
+										"ofType": map[string]any{
 											"kind": "OBJECT",
 											"name": "__InputValue",
 										},
@@ -424,13 +424,13 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "type",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind":   "OBJECT",
 									"name":   "__Type",
 									"ofType": nil,
@@ -439,13 +439,13 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "isDeprecated",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind":   "SCALAR",
 									"name":   "Boolean",
 									"ofType": nil,
@@ -454,10 +454,10 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "deprecationReason",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind":   "SCALAR",
 								"name":   "String",
 								"ofType": nil,
@@ -467,21 +467,21 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 						},
 					},
 					"inputFields":   nil,
-					"interfaces":    []interface{}{},
+					"interfaces":    []any{},
 					"enumValues":    nil,
 					"possibleTypes": nil,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"kind": "OBJECT",
 					"name": "__InputValue",
-					"fields": []interface{}{
-						map[string]interface{}{
+					"fields": []any{
+						map[string]any{
 							"name": "name",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind":   "SCALAR",
 									"name":   "String",
 									"ofType": nil,
@@ -490,10 +490,10 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "description",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind":   "SCALAR",
 								"name":   "String",
 								"ofType": nil,
@@ -501,13 +501,13 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "type",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind":   "OBJECT",
 									"name":   "__Type",
 									"ofType": nil,
@@ -516,10 +516,10 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "defaultValue",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind":   "SCALAR",
 								"name":   "String",
 								"ofType": nil,
@@ -529,21 +529,21 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 						},
 					},
 					"inputFields":   nil,
-					"interfaces":    []interface{}{},
+					"interfaces":    []any{},
 					"enumValues":    nil,
 					"possibleTypes": nil,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"kind": "OBJECT",
 					"name": "__EnumValue",
-					"fields": []interface{}{
-						map[string]interface{}{
+					"fields": []any{
+						map[string]any{
 							"name": "name",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind":   "SCALAR",
 									"name":   "String",
 									"ofType": nil,
@@ -552,10 +552,10 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "description",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind":   "SCALAR",
 								"name":   "String",
 								"ofType": nil,
@@ -563,13 +563,13 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "isDeprecated",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind":   "SCALAR",
 									"name":   "Boolean",
 									"ofType": nil,
@@ -578,10 +578,10 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "deprecationReason",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind":   "SCALAR",
 								"name":   "String",
 								"ofType": nil,
@@ -591,21 +591,21 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 						},
 					},
 					"inputFields":   nil,
-					"interfaces":    []interface{}{},
+					"interfaces":    []any{},
 					"enumValues":    nil,
 					"possibleTypes": nil,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"kind": "OBJECT",
 					"name": "__Directive",
-					"fields": []interface{}{
-						map[string]interface{}{
+					"fields": []any{
+						map[string]any{
 							"name": "name",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind":   "SCALAR",
 									"name":   "String",
 									"ofType": nil,
@@ -614,10 +614,10 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "description",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind":   "SCALAR",
 								"name":   "String",
 								"ofType": nil,
@@ -625,19 +625,19 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "locations",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind": "LIST",
 									"name": nil,
-									"ofType": map[string]interface{}{
+									"ofType": map[string]any{
 										"kind": "NON_NULL",
 										"name": nil,
-										"ofType": map[string]interface{}{
+										"ofType": map[string]any{
 											"kind": "ENUM",
 											"name": "__DirectiveLocation",
 										},
@@ -647,19 +647,19 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "args",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind": "LIST",
 									"name": nil,
-									"ofType": map[string]interface{}{
+									"ofType": map[string]any{
 										"kind": "NON_NULL",
 										"name": nil,
-										"ofType": map[string]interface{}{
+										"ofType": map[string]any{
 											"kind": "OBJECT",
 											"name": "__InputValue",
 										},
@@ -669,13 +669,13 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "onOperation",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind":   "SCALAR",
 									"name":   "Boolean",
 									"ofType": nil,
@@ -684,13 +684,13 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      true,
 							"deprecationReason": "Use `locations`.",
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "onFragment",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind":   "SCALAR",
 									"name":   "Boolean",
 									"ofType": nil,
@@ -699,13 +699,13 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 							"isDeprecated":      true,
 							"deprecationReason": "Use `locations`.",
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "onField",
-							"args": []interface{}{},
-							"type": map[string]interface{}{
+							"args": []any{},
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind":   "SCALAR",
 									"name":   "Boolean",
 									"ofType": nil,
@@ -716,48 +716,48 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 						},
 					},
 					"inputFields":   nil,
-					"interfaces":    []interface{}{},
+					"interfaces":    []any{},
 					"enumValues":    nil,
 					"possibleTypes": nil,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"kind":        "ENUM",
 					"name":        "__DirectiveLocation",
 					"fields":      nil,
 					"inputFields": nil,
 					"interfaces":  nil,
-					"enumValues": []interface{}{
-						map[string]interface{}{
+					"enumValues": []any{
+						map[string]any{
 							"name":              "QUERY",
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name":              "MUTATION",
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name":              "SUBSCRIPTION",
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name":              "FIELD",
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name":              "FRAGMENT_DEFINITION",
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name":              "FRAGMENT_SPREAD",
 							"isDeprecated":      false,
 							"deprecationReason": nil,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name":              "INLINE_FRAGMENT",
 							"isDeprecated":      false,
 							"deprecationReason": nil,
@@ -766,22 +766,22 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 					"possibleTypes": nil,
 				},
 			},
-			"directives": []interface{}{
-				map[string]interface{}{
+			"directives": []any{
+				map[string]any{
 					"name": "include",
-					"locations": []interface{}{
+					"locations": []any{
 						"FIELD",
 						"FRAGMENT_SPREAD",
 						"INLINE_FRAGMENT",
 					},
-					"args": []interface{}{
-						map[string]interface{}{
+					"args": []any{
+						map[string]any{
 							"defaultValue": nil,
 							"name":         "if",
-							"type": map[string]interface{}{
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind":   "SCALAR",
 									"name":   "Boolean",
 									"ofType": nil,
@@ -794,21 +794,21 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 					"onFragment":  true,
 					"onField":     true,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"name": "skip",
-					"locations": []interface{}{
+					"locations": []any{
 						"FIELD",
 						"FRAGMENT_SPREAD",
 						"INLINE_FRAGMENT",
 					},
-					"args": []interface{}{
-						map[string]interface{}{
+					"args": []any{
+						map[string]any{
 							"defaultValue": nil,
 							"name":         "if",
-							"type": map[string]interface{}{
+							"type": map[string]any{
 								"kind": "NON_NULL",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind":   "SCALAR",
 									"name":   "Boolean",
 									"ofType": nil,
@@ -828,7 +828,7 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 		Schema:        emptySchema,
 		RequestString: testutil.IntrospectionQuery,
 	})
-	if !testutil.ContainSubset(result.Data.(map[string]interface{}), expectedDataSubSet) {
+	if !testutil.ContainSubset(result.Data.(map[string]any), expectedDataSubSet) {
 		t.Fatalf("unexpected, result does not contain subset of expected data")
 	}
 }
@@ -857,7 +857,7 @@ func TestIntrospection_ExecutesAnInputObject(t *testing.T) {
 						Type: testInputObject,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					return p.Args["complex"], nil
 				},
 			},
@@ -901,28 +901,28 @@ func TestIntrospection_ExecutesAnInputObject(t *testing.T) {
         }
       }
     `
-	expectedDataSubSet := map[string]interface{}{
-		"__schema": map[string]interface{}{
-			"types": []interface{}{
-				map[string]interface{}{
+	expectedDataSubSet := map[string]any{
+		"__schema": map[string]any{
+			"types": []any{
+				map[string]any{
 					"kind": "INPUT_OBJECT",
 					"name": "TestInputObject",
-					"inputFields": []interface{}{
-						map[string]interface{}{
+					"inputFields": []any{
+						map[string]any{
 							"name": "a",
-							"type": map[string]interface{}{
+							"type": map[string]any{
 								"kind":   "SCALAR",
 								"name":   "String",
 								"ofType": nil,
 							},
 							"defaultValue": `"foo"`,
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name": "b",
-							"type": map[string]interface{}{
+							"type": map[string]any{
 								"kind": "LIST",
 								"name": nil,
-								"ofType": map[string]interface{}{
+								"ofType": map[string]any{
 									"kind":   "SCALAR",
 									"name":   "String",
 									"ofType": nil,
@@ -940,7 +940,7 @@ func TestIntrospection_ExecutesAnInputObject(t *testing.T) {
 		Schema:        schema,
 		RequestString: query,
 	})
-	if !testutil.ContainSubset(result.Data.(map[string]interface{}), expectedDataSubSet) {
+	if !testutil.ContainSubset(result.Data.(map[string]any), expectedDataSubSet) {
 		t.Fatalf("unexpected, result does not contain subset of expected data")
 	}
 }
@@ -969,8 +969,8 @@ func TestIntrospection_SupportsThe__TypeRootField(t *testing.T) {
       }
     `
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"__type": map[string]interface{}{
+		Data: map[string]any{
+			"__type": map[string]any{
 				"name": "TestType",
 			},
 		},
@@ -1016,16 +1016,16 @@ func TestIntrospection_IdentifiesDeprecatedFields(t *testing.T) {
       }
     `
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"__type": map[string]interface{}{
+		Data: map[string]any{
+			"__type": map[string]any{
 				"name": "TestType",
-				"fields": []interface{}{
-					map[string]interface{}{
+				"fields": []any{
+					map[string]any{
 						"name":              "nonDeprecated",
 						"isDeprecated":      false,
 						"deprecationReason": nil,
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name":              "deprecated",
 						"isDeprecated":      true,
 						"deprecationReason": "Removed in 1.0",
@@ -1038,7 +1038,7 @@ func TestIntrospection_IdentifiesDeprecatedFields(t *testing.T) {
 		Schema:        schema,
 		RequestString: query,
 	})
-	if !testutil.ContainSubset(result.Data.(map[string]interface{}), expected.Data.(map[string]interface{})) {
+	if !testutil.ContainSubset(result.Data.(map[string]any), expected.Data.(map[string]any)) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1079,24 +1079,24 @@ func TestIntrospection_RespectsTheIncludeDeprecatedParameterForFields(t *testing
       }
     `
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"__type": map[string]interface{}{
+		Data: map[string]any{
+			"__type": map[string]any{
 				"name": "TestType",
-				"trueFields": []interface{}{
-					map[string]interface{}{
+				"trueFields": []any{
+					map[string]any{
 						"name": "nonDeprecated",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name": "deprecated",
 					},
 				},
-				"falseFields": []interface{}{
-					map[string]interface{}{
+				"falseFields": []any{
+					map[string]any{
 						"name": "nonDeprecated",
 					},
 				},
-				"omittedFields": []interface{}{
-					map[string]interface{}{
+				"omittedFields": []any{
+					map[string]any{
 						"name": "nonDeprecated",
 					},
 				},
@@ -1107,7 +1107,7 @@ func TestIntrospection_RespectsTheIncludeDeprecatedParameterForFields(t *testing
 		Schema:        schema,
 		RequestString: query,
 	})
-	if !testutil.ContainSubset(result.Data.(map[string]interface{}), expected.Data.(map[string]interface{})) {
+	if !testutil.ContainSubset(result.Data.(map[string]any), expected.Data.(map[string]any)) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1155,21 +1155,21 @@ func TestIntrospection_IdentifiesDeprecatedEnumValues(t *testing.T) {
       }
     `
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"__type": map[string]interface{}{
+		Data: map[string]any{
+			"__type": map[string]any{
 				"name": "TestEnum",
-				"enumValues": []interface{}{
-					map[string]interface{}{
+				"enumValues": []any{
+					map[string]any{
 						"name":              "NONDEPRECATED",
 						"isDeprecated":      false,
 						"deprecationReason": nil,
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name":              "DEPRECATED",
 						"isDeprecated":      true,
 						"deprecationReason": "Removed in 1.0",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name":              "ALSONONDEPRECATED",
 						"isDeprecated":      false,
 						"deprecationReason": nil,
@@ -1182,7 +1182,7 @@ func TestIntrospection_IdentifiesDeprecatedEnumValues(t *testing.T) {
 		Schema:        schema,
 		RequestString: query,
 	})
-	if !testutil.ContainSubset(result.Data.(map[string]interface{}), expected.Data.(map[string]interface{})) {
+	if !testutil.ContainSubset(result.Data.(map[string]any), expected.Data.(map[string]any)) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1234,33 +1234,33 @@ func TestIntrospection_RespectsTheIncludeDeprecatedParameterForEnumValues(t *tes
       }
     `
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"__type": map[string]interface{}{
+		Data: map[string]any{
+			"__type": map[string]any{
 				"name": "TestEnum",
-				"trueValues": []interface{}{
-					map[string]interface{}{
+				"trueValues": []any{
+					map[string]any{
 						"name": "NONDEPRECATED",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name": "DEPRECATED",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name": "ALSONONDEPRECATED",
 					},
 				},
-				"falseValues": []interface{}{
-					map[string]interface{}{
+				"falseValues": []any{
+					map[string]any{
 						"name": "NONDEPRECATED",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name": "ALSONONDEPRECATED",
 					},
 				},
-				"omittedValues": []interface{}{
-					map[string]interface{}{
+				"omittedValues": []any{
+					map[string]any{
 						"name": "NONDEPRECATED",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name": "ALSONONDEPRECATED",
 					},
 				},
@@ -1271,7 +1271,7 @@ func TestIntrospection_RespectsTheIncludeDeprecatedParameterForEnumValues(t *tes
 		Schema:        schema,
 		RequestString: query,
 	})
-	if !testutil.ContainSubset(result.Data.(map[string]interface{}), expected.Data.(map[string]interface{})) {
+	if !testutil.ContainSubset(result.Data.(map[string]any), expected.Data.(map[string]any)) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1348,33 +1348,33 @@ func TestIntrospection_ExposesDescriptionsOnTypesAndFields(t *testing.T) {
     `
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"schemaType": map[string]interface{}{
+		Data: map[string]any{
+			"schemaType": map[string]any{
 				"name": "__Schema",
 				"description": `A GraphQL Schema defines the capabilities of a GraphQL ` +
 					`server. It exposes all available types and directives on ` +
 					`the server, as well as the entry points for query, mutation, ` +
 					`and subscription operations.`,
-				"fields": []interface{}{
-					map[string]interface{}{
+				"fields": []any{
+					map[string]any{
 						"name":        "types",
 						"description": "A list of all types supported by this server.",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name":        "queryType",
 						"description": "The type that query operations will be rooted at.",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name": "mutationType",
 						"description": "If this server supports mutation, the type that " +
 							"mutation operations will be rooted at.",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name": "subscriptionType",
 						"description": "If this server supports subscription, the type that " +
 							"subscription operations will be rooted at.",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name":        "directives",
 						"description": "A list of all directives supported by this server.",
 					},
@@ -1386,7 +1386,7 @@ func TestIntrospection_ExposesDescriptionsOnTypesAndFields(t *testing.T) {
 		Schema:        schema,
 		RequestString: query,
 	})
-	if !testutil.ContainSubset(result.Data.(map[string]interface{}), expected.Data.(map[string]interface{})) {
+	if !testutil.ContainSubset(result.Data.(map[string]any), expected.Data.(map[string]any)) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1419,40 +1419,40 @@ func TestIntrospection_ExposesDescriptionsOnEnums(t *testing.T) {
       }
     `
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"typeKindType": map[string]interface{}{
+		Data: map[string]any{
+			"typeKindType": map[string]any{
 				"name":        "__TypeKind",
 				"description": "An enum describing what kind of type a given `__Type` is",
-				"enumValues": []interface{}{
-					map[string]interface{}{
+				"enumValues": []any{
+					map[string]any{
 						"name":        "SCALAR",
 						"description": "Indicates this type is a scalar.",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name":        "OBJECT",
 						"description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name":        "INTERFACE",
 						"description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name":        "UNION",
 						"description": "Indicates this type is a union. `possibleTypes` is a valid field.",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name":        "ENUM",
 						"description": "Indicates this type is an enum. `enumValues` is a valid field.",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name":        "INPUT_OBJECT",
 						"description": "Indicates this type is an input object. `inputFields` is a valid field.",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name":        "LIST",
 						"description": "Indicates this type is a list. `ofType` is a valid field.",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name":        "NON_NULL",
 						"description": "Indicates this type is a non-null. `ofType` is a valid field.",
 					},
@@ -1464,7 +1464,7 @@ func TestIntrospection_ExposesDescriptionsOnEnums(t *testing.T) {
 		Schema:        schema,
 		RequestString: query,
 	})
-	if !testutil.ContainSubset(result.Data.(map[string]interface{}), expected.Data.(map[string]interface{})) {
+	if !testutil.ContainSubset(result.Data.(map[string]any), expected.Data.(map[string]any)) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }

--- a/introspection_test.go
+++ b/introspection_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/machship/graphql/testutil"
 )
 
-func g(t *testing.T, p graphql.Params) *graphql.Result {
+func g(_ *testing.T, p graphql.Params) *graphql.Result {
 	return graphql.Do(p)
 }
 

--- a/language/ast/values.go
+++ b/language/ast/values.go
@@ -5,7 +5,7 @@ import (
 )
 
 type Value interface {
-	GetValue() interface{}
+	GetValue() any
 	GetKind() string
 	GetLoc() *Location
 }
@@ -44,11 +44,11 @@ func (v *Variable) GetLoc() *Location {
 }
 
 // GetValue alias to Variable.GetName()
-func (v *Variable) GetValue() interface{} {
+func (v *Variable) GetValue() any {
 	return v.GetName()
 }
 
-func (v *Variable) GetName() interface{} {
+func (v *Variable) GetName() any {
 	return v.Name
 }
 
@@ -78,7 +78,7 @@ func (v *IntValue) GetLoc() *Location {
 	return v.Loc
 }
 
-func (v *IntValue) GetValue() interface{} {
+func (v *IntValue) GetValue() any {
 	return v.Value
 }
 
@@ -108,7 +108,7 @@ func (v *FloatValue) GetLoc() *Location {
 	return v.Loc
 }
 
-func (v *FloatValue) GetValue() interface{} {
+func (v *FloatValue) GetValue() any {
 	return v.Value
 }
 
@@ -138,7 +138,7 @@ func (v *StringValue) GetLoc() *Location {
 	return v.Loc
 }
 
-func (v *StringValue) GetValue() interface{} {
+func (v *StringValue) GetValue() any {
 	return v.Value
 }
 
@@ -168,7 +168,7 @@ func (v *BooleanValue) GetLoc() *Location {
 	return v.Loc
 }
 
-func (v *BooleanValue) GetValue() interface{} {
+func (v *BooleanValue) GetValue() any {
 	return v.Value
 }
 
@@ -198,7 +198,7 @@ func (v *EnumValue) GetLoc() *Location {
 	return v.Loc
 }
 
-func (v *EnumValue) GetValue() interface{} {
+func (v *EnumValue) GetValue() any {
 	return v.Value
 }
 
@@ -229,11 +229,11 @@ func (v *ListValue) GetLoc() *Location {
 }
 
 // GetValue alias to ListValue.GetValues()
-func (v *ListValue) GetValue() interface{} {
+func (v *ListValue) GetValue() any {
 	return v.GetValues()
 }
 
-func (v *ListValue) GetValues() interface{} {
+func (v *ListValue) GetValues() any {
 	// TODO: verify ObjectValue.GetValue()
 	return v.Values
 }
@@ -264,7 +264,7 @@ func (v *ObjectValue) GetLoc() *Location {
 	return v.Loc
 }
 
-func (v *ObjectValue) GetValue() interface{} {
+func (v *ObjectValue) GetValue() any {
 	// TODO: verify ObjectValue.GetValue()
 	return v.Fields
 }
@@ -297,6 +297,6 @@ func (f *ObjectField) GetLoc() *Location {
 	return f.Loc
 }
 
-func (f *ObjectField) GetValue() interface{} {
+func (f *ObjectField) GetValue() any {
 	return f.Value
 }

--- a/language/lexer/lexer.go
+++ b/language/lexer/lexer.go
@@ -210,8 +210,7 @@ func readDigits(s *source.Source, start int, firstCode rune, codeLength int) (in
 		}
 		return position, nil
 	}
-	var description string
-	description = fmt.Sprintf("Invalid number, expected digit but got: %v.", printCharCode(code))
+	description := fmt.Sprintf("Invalid number, expected digit but got: %v.", printCharCode(code))
 	return position, gqlerrors.NewSyntaxError(s, position, description)
 }
 
@@ -243,28 +242,20 @@ func readString(s *source.Source, start int) (Token, error) {
 				switch code {
 				case '"':
 					valueBuffer.WriteRune('"')
-					break
 				case '/':
 					valueBuffer.WriteRune('/')
-					break
 				case '\\':
 					valueBuffer.WriteRune('\\')
-					break
 				case 'b':
 					valueBuffer.WriteRune('\b')
-					break
 				case 'f':
 					valueBuffer.WriteRune('\f')
-					break
 				case 'n':
 					valueBuffer.WriteRune('\n')
-					break
 				case 'r':
 					valueBuffer.WriteRune('\r')
-					break
 				case 't':
 					valueBuffer.WriteRune('\t')
-					break
 				case 'u':
 					// Check if there are at least 4 bytes available
 					if len(body) <= position+4 {
@@ -286,7 +277,6 @@ func readString(s *source.Source, start int) (Token, error) {
 					valueBuffer.WriteRune(charCode)
 					position += 4
 					runePosition += 4
-					break
 				default:
 					return Token{}, gqlerrors.NewSyntaxError(s, runePosition,
 						fmt.Sprintf(`Invalid character escape sequence: \\%c.`, code))
@@ -516,7 +506,6 @@ func readToken(s *source.Source, fromPosition int) (Token, error) {
 		if next1 == '.' && next2 == '.' {
 			return makeToken(SPREAD, position, position+3, ""), nil
 		}
-		break
 	// :
 	case ':':
 		return makeToken(COLON, position, position+1, ""), nil

--- a/language/lexer/lexer_test.go
+++ b/language/lexer/lexer_test.go
@@ -9,7 +9,7 @@ import (
 
 type Test struct {
 	Body     string
-	Expected interface{}
+	Expected any
 }
 
 func createSource(body string) *source.Source {

--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -9,7 +9,7 @@ import (
 	"github.com/machship/graphql/language/source"
 )
 
-type parseFn func(parser *Parser) (interface{}, error)
+type parseFn func(parser *Parser) (any, error)
 
 // parse operation, fragment, typeSystem{schema, type..., extension, directives} definition
 type parseDefinitionFn func(parser *Parser) (ast.Node, error)
@@ -41,7 +41,7 @@ type ParseOptions struct {
 }
 
 type ParseParams struct {
-	Source  interface{}
+	Source  any
 	Options ParseOptions
 }
 
@@ -258,7 +258,7 @@ func parseVariableDefinitions(parser *Parser) ([]*ast.VariableDefinition, error)
 /**
  * VariableDefinition : Variable : Type DefaultValue?
  */
-func parseVariableDefinition(parser *Parser) (interface{}, error) {
+func parseVariableDefinition(parser *Parser) (any, error) {
 	var (
 		variable *ast.Variable
 		ttype    ast.Type
@@ -340,7 +340,7 @@ func parseSelectionSet(parser *Parser) (*ast.SelectionSet, error) {
  *   - FragmentSpread
  *   - InlineFragment
  */
-func parseSelection(parser *Parser) (interface{}, error) {
+func parseSelection(parser *Parser) (any, error) {
 	if peek(parser, lexer.SPREAD) {
 		return parseFragment(parser)
 	}
@@ -417,7 +417,7 @@ func parseArguments(parser *Parser) ([]*ast.Argument, error) {
 /**
  * Argument : Name : Value
  */
-func parseArgument(parser *Parser) (interface{}, error) {
+func parseArgument(parser *Parser) (any, error) {
 	var (
 		err   error
 		name  *ast.Name
@@ -449,7 +449,7 @@ func parseArgument(parser *Parser) (interface{}, error) {
  *
  * InlineFragment : ... TypeCondition? Directives? SelectionSet
  */
-func parseFragment(parser *Parser) (interface{}, error) {
+func parseFragment(parser *Parser) (any, error) {
 	var (
 		err error
 	)
@@ -624,7 +624,7 @@ func parseValueLiteral(parser *Parser, isConst bool) (ast.Value, error) {
 	return nil, unexpected(parser, lexer.Token{})
 }
 
-func parseConstValue(parser *Parser) (interface{}, error) {
+func parseConstValue(parser *Parser) (any, error) {
 	value, err := parseValueLiteral(parser, true)
 	if err != nil {
 		return value, err
@@ -632,7 +632,7 @@ func parseConstValue(parser *Parser) (interface{}, error) {
 	return value, nil
 }
 
-func parseValueValue(parser *Parser) (interface{}, error) {
+func parseValueValue(parser *Parser) (any, error) {
 	return parseValueLiteral(parser, false)
 }
 
@@ -899,7 +899,7 @@ func parseSchemaDefinition(parser *Parser) (ast.Node, error) {
 	}), nil
 }
 
-func parseOperationTypeDefinition(parser *Parser) (interface{}, error) {
+func parseOperationTypeDefinition(parser *Parser) (any, error) {
 	start := parser.Token.Start
 	operation, err := parseOperationType(parser)
 	if err != nil {
@@ -1032,7 +1032,7 @@ func parseImplementsInterfaces(parser *Parser) ([]*ast.Named, error) {
 /**
  * FieldDefinition : Description? Name ArgumentsDefinition? : Type Directives?
  */
-func parseFieldDefinition(parser *Parser) (interface{}, error) {
+func parseFieldDefinition(parser *Parser) (any, error) {
 	start := parser.Token.Start
 	description, err := parseDescription(parser)
 	if err != nil {
@@ -1095,7 +1095,7 @@ func parseArgumentDefs(parser *Parser) ([]*ast.InputValueDefinition, error) {
 /**
  * InputValueDefinition : Description? Name : Type DefaultValue? Directives?
  */
-func parseInputValueDef(parser *Parser) (interface{}, error) {
+func parseInputValueDef(parser *Parser) (any, error) {
 	var (
 		description *ast.StringValue
 		name        *ast.Name
@@ -1294,7 +1294,7 @@ func parseEnumTypeDefinition(parser *Parser) (ast.Node, error) {
  *
  * EnumValue : Name
  */
-func parseEnumValueDefinition(parser *Parser) (interface{}, error) {
+func parseEnumValueDefinition(parser *Parser) (any, error) {
 	start := parser.Token.Start
 	description, err := parseDescription(parser)
 	if err != nil {
@@ -1562,17 +1562,18 @@ func unexpectedEmpty(parser *Parser, beginLoc int, openKind, closeKind lexer.Tok
 	return gqlerrors.NewSyntaxError(parser.Source, beginLoc, description)
 }
 
-//  Returns list of parse nodes, determined by
+//	Returns list of parse nodes, determined by
+//
 // the parseFn. This list begins with a lex token of openKind
 // and ends with a lex token of closeKind. Advances the parser
 // to the next lex token after the closing token.
 // if zinteger is true, len(nodes) > 0
-func reverse(parser *Parser, openKind lexer.TokenKind, parseFn parseFn, closeKind lexer.TokenKind, zinteger bool) ([]interface{}, error) {
+func reverse(parser *Parser, openKind lexer.TokenKind, parseFn parseFn, closeKind lexer.TokenKind, zinteger bool) ([]any, error) {
 	token, err := expect(parser, openKind)
 	if err != nil {
 		return nil, err
 	}
-	var nodes []interface{}
+	var nodes []any
 	for {
 		if skp, err := skip(parser, closeKind); err != nil {
 			return nil, err

--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -746,7 +746,7 @@ func TestDoesNotAcceptStringAsDefinition(t *testing.T) {
 }
 
 type errorMessageTest struct {
-	source          interface{}
+	source          any
 	expectedMessage string
 	skipped         bool
 }

--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -2,7 +2,7 @@ package parser
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -347,7 +347,7 @@ func TestParsesMultiByteCharacters_UnicodeText(t *testing.T) {
 }
 
 func TestParsesKitchenSink(t *testing.T) {
-	b, err := ioutil.ReadFile("../../kitchen-sink.graphql")
+	b, err := os.ReadFile("../../kitchen-sink.graphql")
 	if err != nil {
 		t.Fatalf("unable to load kitchen-sink.graphql")
 	}

--- a/language/parser/schema_parser_test.go
+++ b/language/parser/schema_parser_test.go
@@ -825,7 +825,7 @@ input Hello {
 	if err == nil {
 		t.Fatalf("expected error, expected: %v, got: %v", expectedError, nil)
 	}
-	if !reflect.DeepEqual(expectedError, err) {
+	if err.Error() != expectedError.Error() {
 		t.Fatalf("unexpected document, expected: %v, got: %v", expectedError, err)
 	}
 }

--- a/language/printer/printer_test.go
+++ b/language/printer/printer_test.go
@@ -1,7 +1,7 @@
 package printer_test
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -25,7 +25,7 @@ func parse(t *testing.T, query string) *ast.Document {
 }
 
 func TestPrinter_DoesNotAlterAST(t *testing.T) {
-	b, err := ioutil.ReadFile("../../kitchen-sink.graphql")
+	b, err := os.ReadFile("../../kitchen-sink.graphql")
 	if err != nil {
 		t.Fatalf("unable to load kitchen-sink.graphql")
 	}
@@ -122,7 +122,7 @@ func TestPrinter_CorrectlyPrintsNonQueryOperationsWithoutName(t *testing.T) {
 }
 
 func TestPrinter_PrintsKitchenSink(t *testing.T) {
-	b, err := ioutil.ReadFile("../../kitchen-sink.graphql")
+	b, err := os.ReadFile("../../kitchen-sink.graphql")
 	if err != nil {
 		t.Fatalf("unable to load kitchen-sink.graphql")
 	}

--- a/language/printer/schema_printer_test.go
+++ b/language/printer/schema_printer_test.go
@@ -1,7 +1,7 @@
 package printer_test
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -24,7 +24,7 @@ func TestSchemaPrinter_PrintsMinimalAST(t *testing.T) {
 }
 
 func TestSchemaPrinter_DoesNotAlterAST(t *testing.T) {
-	b, err := ioutil.ReadFile("../../schema-kitchen-sink.graphql")
+	b, err := os.ReadFile("../../schema-kitchen-sink.graphql")
 	if err != nil {
 		t.Fatalf("unable to load schema-kitchen-sink.graphql")
 	}
@@ -46,7 +46,7 @@ func TestSchemaPrinter_DoesNotAlterAST(t *testing.T) {
 }
 
 func TestSchemaPrinter_PrintsKitchenSink(t *testing.T) {
-	b, err := ioutil.ReadFile("../../schema-kitchen-sink.graphql")
+	b, err := os.ReadFile("../../schema-kitchen-sink.graphql")
 	if err != nil {
 		t.Fatalf("unable to load schema-kitchen-sink.graphql")
 	}
@@ -126,7 +126,7 @@ directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 }
 
 func TestSchemaPrinter_PrintsAllDescriptions(t *testing.T) {
-	b, err := ioutil.ReadFile("../../schema-all-descriptions.graphql")
+	b, err := os.ReadFile("../../schema-all-descriptions.graphql")
 	if err != nil {
 		t.Fatalf("unable to load schema-all-descriptions.graphql")
 	}

--- a/language/visitor/visitor.go
+++ b/language/visitor/visitor.go
@@ -539,11 +539,7 @@ func isSlice(value any) bool {
 	if value == nil {
 		return false
 	}
-	typ := reflect.TypeOf(value)
-	if typ.Kind() == reflect.Slice {
-		return true
-	}
-	return false
+	return reflect.TypeOf(value).Kind() == reflect.Slice
 }
 
 func isStructNode(node any) bool {
@@ -571,11 +567,8 @@ func isNode(node any) bool {
 	if !val.IsValid() {
 		return false
 	}
-	switch val.Kind() {
-	case reflect.Map:
+	if val.Kind() == reflect.Map {
 		return true
-	case reflect.Ptr:
-		val = val.Elem()
 	}
 	_, ok := node.(ast.Node)
 	return ok

--- a/language/visitor/visitor.go
+++ b/language/visitor/visitor.go
@@ -143,25 +143,25 @@ var QueryDocumentKeys = KeyMap{
 
 type stack struct {
 	Index   int
-	Keys    []interface{}
+	Keys    []any
 	Edits   []*edit
 	inSlice bool
 	Prev    *stack
 }
 type edit struct {
-	Key   interface{}
-	Value interface{}
+	Key   any
+	Value any
 }
 
 type VisitFuncParams struct {
-	Node      interface{}
-	Key       interface{}
+	Node      any
+	Key       any
 	Parent    ast.Node
-	Path      []interface{}
+	Path      []any
 	Ancestors []ast.Node
 }
 
-type VisitFunc func(p VisitFuncParams) (string, interface{})
+type VisitFunc func(p VisitFuncParams) (string, any)
 
 type NamedVisitFuncs struct {
 	Kind  VisitFunc // 1) Named visitors triggered when entering a node a specific kind.
@@ -178,26 +178,26 @@ type VisitorOptions struct {
 	LeaveKindMap map[string]VisitFunc // 4) Parallel visitors for entering and leaving nodes of a specific kind
 }
 
-func Visit(root ast.Node, visitorOpts *VisitorOptions, keyMap KeyMap) interface{} {
+func Visit(root ast.Node, visitorOpts *VisitorOptions, keyMap KeyMap) any {
 	visitorKeys := keyMap
 	if visitorKeys == nil {
 		visitorKeys = QueryDocumentKeys
 	}
 
 	var (
-		result         interface{}
+		result         any
 		newRoot        ast.Node = root
 		sstack         *stack
-		parent         interface{}
-		parentSlice    []interface{}
+		parent         any
+		parentSlice    []any
 		inSlice        = false
 		prevInSlice    = false
-		keys           = []interface{}{root}
+		keys           = []any{root}
 		index          = -1
 		edits          = []*edit{} // key-value
-		path           = []interface{}{}
-		ancestors      = []interface{}{}
-		ancestorsSlice = [][]interface{}{}
+		path           = []any{}
+		ancestors      = []any{}
+		ancestorsSlice = [][]any{}
 	)
 	// these algorithm must be simple!!!
 	// abstract algorithm
@@ -207,9 +207,9 @@ Loop:
 
 		isLeaving := (len(keys) == index)
 		var (
-			key       interface{} // string for structs or int for slices
-			node      interface{} // ast.Node or can be anything
-			nodeSlice []interface{}
+			key       any // string for structs or int for slices
+			node      any // ast.Node or can be anything
+			nodeSlice []any
 		)
 		isEdited := (isLeaving && len(edits) != 0)
 
@@ -272,13 +272,13 @@ Loop:
 				key = getFieldValue(keys, index)
 			}
 			// get node
-			var tmp interface{}
+			var tmp any
 			if !isNilNode(parent) {
 				tmp = parent
 			} else if len(parentSlice) != 0 {
 				tmp = parentSlice
 			} else {
-				node, nodeSlice = newRoot, []interface{}{}
+				node, nodeSlice = newRoot, []any{}
 			}
 			if tmp != nil {
 				fieldValue := getFieldValue(tmp, key)
@@ -306,7 +306,7 @@ Loop:
 		}
 
 		// get result from visitFn for a node if set
-		var result interface{}
+		var result any
 		resultIsUndefined := true
 		if !isNilNode(node) {
 			// Note that since user can potentially return a non-ast.Node from visit functions.
@@ -323,7 +323,7 @@ Loop:
 
 			var kind string
 			switch tmp := node.(type) {
-			case map[string]interface{}:
+			case map[string]any:
 				kind = tmp["Kind"].(string)
 			case ast.Node:
 				kind = tmp.GetKind()
@@ -391,7 +391,7 @@ Loop:
 			}
 
 			// replace keys
-			keys, index, edits = []interface{}{}, -1, []*edit{}
+			keys, index, edits = []any{}, -1, []*edit{}
 			if len(nodeSlice) > 0 {
 				inSlice = true
 				keys = append(keys, nodeSlice...)
@@ -421,28 +421,28 @@ Loop:
 	return result
 }
 
-func pop(a []interface{}) (interface{}, []interface{}) {
+func pop(a []any) (any, []any) {
 	if len(a) == 0 {
 		return nil, nil
 	}
 	return a[len(a)-1], a[:len(a)-1]
 }
 
-func popNodeSlice(a [][]interface{}) ([]interface{}, [][]interface{}) {
+func popNodeSlice(a [][]any) ([]any, [][]any) {
 	if len(a) == 0 {
 		return nil, nil
 	}
 	return a[len(a)-1], a[:len(a)-1]
 }
 
-func removeNodeByIndex(a []interface{}, pos int) []interface{} {
+func removeNodeByIndex(a []any, pos int) []any {
 	if pos < 0 || pos >= len(a) {
 		return a
 	}
 	return append(a[:pos], a[pos+1:]...)
 }
 
-func convertMap(src interface{}) (dest map[string]interface{}, err error) {
+func convertMap(src any) (dest map[string]any, err error) {
 	if src == nil {
 		return
 	}
@@ -460,7 +460,7 @@ func convertMap(src interface{}) (dest map[string]interface{}, err error) {
 // when obj type is struct, the key's type must be string
 // ... slice, ... int
 // ... map, ... any type. But the type satisfies map's key definition(feature: compare...)
-func getFieldValue(obj interface{}, key interface{}) interface{} {
+func getFieldValue(obj any, key any) any {
 	var value reflect.Value
 	val := reflect.ValueOf(obj)
 	if val.Kind() == reflect.Ptr {
@@ -485,7 +485,7 @@ func getFieldValue(obj interface{}, key interface{}) interface{} {
 }
 
 // currently only supports update struct field value
-func updateNodeField(src interface{}, targetName string, target interface{}) interface{} {
+func updateNodeField(src any, targetName string, target any) any {
 	var isPtr bool
 	srcVal := reflect.ValueOf(src)
 	// verify condition
@@ -520,8 +520,8 @@ func updateNodeField(src interface{}, targetName string, target interface{}) int
 	return srcVal.Interface()
 }
 
-func toSliceInterfaces(src interface{}) []interface{} {
-	var list []interface{}
+func toSliceInterfaces(src any) []any {
+	var list []any
 	value := reflect.ValueOf(src)
 	if value.Kind() == reflect.Ptr {
 		value = value.Elem()
@@ -535,7 +535,7 @@ func toSliceInterfaces(src interface{}) []interface{} {
 	return list
 }
 
-func isSlice(value interface{}) bool {
+func isSlice(value any) bool {
 	if value == nil {
 		return false
 	}
@@ -546,7 +546,7 @@ func isSlice(value interface{}) bool {
 	return false
 }
 
-func isStructNode(node interface{}) bool {
+func isStructNode(node any) bool {
 	if node == nil {
 		return false
 	}
@@ -563,7 +563,7 @@ func isStructNode(node interface{}) bool {
 
 // notice: type: Named, List or NonNull maybe map type
 // and it can't be asserted to ast.Node
-func isNode(node interface{}) bool {
+func isNode(node any) bool {
 	if node == nil {
 		return false
 	}
@@ -581,7 +581,7 @@ func isNode(node interface{}) bool {
 	return ok
 }
 
-func isNilNode(node interface{}) bool {
+func isNilNode(node any) bool {
 	if node == nil {
 		return true
 	}
@@ -603,10 +603,10 @@ func isNilNode(node interface{}) bool {
 //
 // If a prior visitor edits a node, no following visitors will see that node.
 func VisitInParallel(visitorOptsSlice ...*VisitorOptions) *VisitorOptions {
-	skipping := map[int]interface{}{}
+	skipping := map[int]any{}
 
 	return &VisitorOptions{
-		Enter: func(p VisitFuncParams) (string, interface{}) {
+		Enter: func(p VisitFuncParams) (string, any) {
 			for i, visitorOpts := range visitorOptsSlice {
 				if _, ok := skipping[i]; !ok {
 					node, ok := p.Node.(ast.Node)
@@ -629,7 +629,7 @@ func VisitInParallel(visitorOptsSlice ...*VisitorOptions) *VisitorOptions {
 			}
 			return ActionNoChange, nil
 		},
-		Leave: func(p VisitFuncParams) (string, interface{}) {
+		Leave: func(p VisitFuncParams) (string, any) {
 			for i, visitorOpts := range visitorOptsSlice {
 				skippedNode, ok := skipping[i]
 				if !ok {
@@ -658,7 +658,7 @@ func VisitInParallel(visitorOptsSlice ...*VisitorOptions) *VisitorOptions {
 // along with visiting visitor.
 func VisitWithTypeInfo(ttypeInfo typeInfo.TypeInfoI, visitorOpts *VisitorOptions) *VisitorOptions {
 	return &VisitorOptions{
-		Enter: func(p VisitFuncParams) (string, interface{}) {
+		Enter: func(p VisitFuncParams) (string, any) {
 			if node, ok := p.Node.(ast.Node); ok {
 				ttypeInfo.Enter(node)
 				fn := GetVisitFn(visitorOpts, node.GetKind(), false)
@@ -677,9 +677,9 @@ func VisitWithTypeInfo(ttypeInfo typeInfo.TypeInfoI, visitorOpts *VisitorOptions
 			}
 			return ActionNoChange, nil
 		},
-		Leave: func(p VisitFuncParams) (string, interface{}) {
+		Leave: func(p VisitFuncParams) (string, any) {
 			action := ActionNoChange
-			var result interface{}
+			var result any
 			if node, ok := p.Node.(ast.Node); ok {
 				fn := GetVisitFn(visitorOpts, node.GetKind(), true)
 				if fn != nil {

--- a/language/visitor/visitor_test.go
+++ b/language/visitor/visitor_test.go
@@ -1,7 +1,7 @@
 package visitor_test
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -478,7 +478,7 @@ func TestVisitor_AllowsANamedFunctionsVisitorAPI(t *testing.T) {
 	}
 }
 func TestVisitor_VisitsKitchenSink(t *testing.T) {
-	b, err := ioutil.ReadFile("../../kitchen-sink.graphql")
+	b, err := os.ReadFile("../../kitchen-sink.graphql")
 	if err != nil {
 		t.Fatalf("unable to load kitchen-sink.graphql")
 	}

--- a/language/visitor/visitor_test.go
+++ b/language/visitor/visitor_test.go
@@ -53,7 +53,7 @@ func TestVisitor_AllowsEditingANodeBothOnEnterAndOnLeave(t *testing.T) {
 
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.OperationDefinition: {
-				Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Enter: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.OperationDefinition); ok {
 						selectionSet = node.SelectionSet
 						visited["didEnter"] = true
@@ -70,7 +70,7 @@ func TestVisitor_AllowsEditingANodeBothOnEnterAndOnLeave(t *testing.T) {
 					}
 					return visitor.ActionNoChange, nil
 				},
-				Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Leave: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.OperationDefinition); ok {
 						visited["didLeave"] = true
 						return visitor.ActionUpdate, ast.NewOperationDefinition(&ast.OperationDefinition{
@@ -122,7 +122,7 @@ func TestVisitor_AllowsEditingTheRootNodeOnEnterAndOnLeave(t *testing.T) {
 
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.Document: {
-				Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Enter: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.Document); ok {
 						visited["didEnter"] = true
 						return visitor.ActionUpdate, ast.NewDocument(&ast.Document{
@@ -132,7 +132,7 @@ func TestVisitor_AllowsEditingTheRootNodeOnEnterAndOnLeave(t *testing.T) {
 					}
 					return visitor.ActionNoChange, nil
 				},
-				Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Leave: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.Document); ok {
 						visited["didLeave"] = true
 						return visitor.ActionUpdate, ast.NewDocument(&ast.Document{
@@ -163,7 +163,7 @@ func TestVisitor_AllowsForEditingOnEnter(t *testing.T) {
 	expectedQuery := `{ a,    c { a,    c } }`
 	expectedAST := parse(t, expectedQuery)
 	v := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Field:
 				if node.Name != nil && node.Name.Value == "b" {
@@ -188,7 +188,7 @@ func TestVisitor_AllowsForEditingOnLeave(t *testing.T) {
 	expectedQuery := `{ a,    c { a,    c } }`
 	expectedAST := parse(t, expectedQuery)
 	v := &visitor.VisitorOptions{
-		Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Leave: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Field:
 				if node.Name != nil && node.Name.Value == "b" {
@@ -220,7 +220,7 @@ func TestVisitor_VisitsEditedNode(t *testing.T) {
 
 	didVisitAddedField := false
 	v := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Field:
 				if node.Name != nil && node.Name.Value == "a" {
@@ -251,50 +251,50 @@ func TestVisitor_AllowsSkippingASubTree(t *testing.T) {
 	query := `{ a, b { x }, c }`
 	astDoc := parse(t, query)
 
-	visited := []interface{}{}
-	expectedVisited := []interface{}{
-		[]interface{}{"enter", "Document", nil},
-		[]interface{}{"enter", "OperationDefinition", nil},
-		[]interface{}{"enter", "SelectionSet", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "a"},
-		[]interface{}{"leave", "Name", "a"},
-		[]interface{}{"leave", "Field", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "c"},
-		[]interface{}{"leave", "Name", "c"},
-		[]interface{}{"leave", "Field", nil},
-		[]interface{}{"leave", "SelectionSet", nil},
-		[]interface{}{"leave", "OperationDefinition", nil},
-		[]interface{}{"leave", "Document", nil},
+	visited := []any{}
+	expectedVisited := []any{
+		[]any{"enter", "Document", nil},
+		[]any{"enter", "OperationDefinition", nil},
+		[]any{"enter", "SelectionSet", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "a"},
+		[]any{"leave", "Name", "a"},
+		[]any{"leave", "Field", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "c"},
+		[]any{"leave", "Name", "c"},
+		[]any{"leave", "Field", nil},
+		[]any{"leave", "SelectionSet", nil},
+		[]any{"leave", "OperationDefinition", nil},
+		[]any{"leave", "Document", nil},
 	}
 
 	v := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"enter", node.Kind, node.Value})
+				visited = append(visited, []any{"enter", node.Kind, node.Value})
 			case *ast.Field:
-				visited = append(visited, []interface{}{"enter", node.Kind, nil})
+				visited = append(visited, []any{"enter", node.Kind, nil})
 				if node.Name != nil && node.Name.Value == "b" {
 					return visitor.ActionSkip, nil
 				}
 			case ast.Node:
-				visited = append(visited, []interface{}{"enter", node.GetKind(), nil})
+				visited = append(visited, []any{"enter", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"enter", nil, nil})
+				visited = append(visited, []any{"enter", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
-		Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Leave: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"leave", node.Kind, node.Value})
+				visited = append(visited, []any{"leave", node.Kind, node.Value})
 			case ast.Node:
-				visited = append(visited, []interface{}{"leave", node.GetKind(), nil})
+				visited = append(visited, []any{"leave", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"leave", nil, nil})
+				visited = append(visited, []any{"leave", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
@@ -309,50 +309,50 @@ func TestVisitor_AllowsSkippingASubTree(t *testing.T) {
 
 func TestVisitor_AllowsEarlyExitWhileVisiting(t *testing.T) {
 
-	visited := []interface{}{}
+	visited := []any{}
 
 	query := `{ a, b { x }, c }`
 	astDoc := parse(t, query)
 
-	expectedVisited := []interface{}{
-		[]interface{}{"enter", "Document", nil},
-		[]interface{}{"enter", "OperationDefinition", nil},
-		[]interface{}{"enter", "SelectionSet", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "a"},
-		[]interface{}{"leave", "Name", "a"},
-		[]interface{}{"leave", "Field", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "b"},
-		[]interface{}{"leave", "Name", "b"},
-		[]interface{}{"enter", "SelectionSet", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "x"},
+	expectedVisited := []any{
+		[]any{"enter", "Document", nil},
+		[]any{"enter", "OperationDefinition", nil},
+		[]any{"enter", "SelectionSet", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "a"},
+		[]any{"leave", "Name", "a"},
+		[]any{"leave", "Field", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "b"},
+		[]any{"leave", "Name", "b"},
+		[]any{"enter", "SelectionSet", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "x"},
 	}
 
 	v := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"enter", node.Kind, node.Value})
+				visited = append(visited, []any{"enter", node.Kind, node.Value})
 				if node.Value == "x" {
 					return visitor.ActionBreak, nil
 				}
 			case ast.Node:
-				visited = append(visited, []interface{}{"enter", node.GetKind(), nil})
+				visited = append(visited, []any{"enter", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"enter", nil, nil})
+				visited = append(visited, []any{"enter", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
-		Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Leave: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"leave", node.Kind, node.Value})
+				visited = append(visited, []any{"leave", node.Kind, node.Value})
 			case ast.Node:
-				visited = append(visited, []interface{}{"leave", node.GetKind(), nil})
+				visited = append(visited, []any{"leave", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"leave", nil, nil})
+				visited = append(visited, []any{"leave", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
@@ -367,51 +367,51 @@ func TestVisitor_AllowsEarlyExitWhileVisiting(t *testing.T) {
 
 func TestVisitor_AllowsEarlyExitWhileLeaving(t *testing.T) {
 
-	visited := []interface{}{}
+	visited := []any{}
 
 	query := `{ a, b { x }, c }`
 	astDoc := parse(t, query)
 
-	expectedVisited := []interface{}{
-		[]interface{}{"enter", "Document", nil},
-		[]interface{}{"enter", "OperationDefinition", nil},
-		[]interface{}{"enter", "SelectionSet", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "a"},
-		[]interface{}{"leave", "Name", "a"},
-		[]interface{}{"leave", "Field", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "b"},
-		[]interface{}{"leave", "Name", "b"},
-		[]interface{}{"enter", "SelectionSet", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "x"},
-		[]interface{}{"leave", "Name", "x"},
+	expectedVisited := []any{
+		[]any{"enter", "Document", nil},
+		[]any{"enter", "OperationDefinition", nil},
+		[]any{"enter", "SelectionSet", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "a"},
+		[]any{"leave", "Name", "a"},
+		[]any{"leave", "Field", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "b"},
+		[]any{"leave", "Name", "b"},
+		[]any{"enter", "SelectionSet", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "x"},
+		[]any{"leave", "Name", "x"},
 	}
 
 	v := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"enter", node.Kind, node.Value})
+				visited = append(visited, []any{"enter", node.Kind, node.Value})
 			case ast.Node:
-				visited = append(visited, []interface{}{"enter", node.GetKind(), nil})
+				visited = append(visited, []any{"enter", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"enter", nil, nil})
+				visited = append(visited, []any{"enter", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
-		Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Leave: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"leave", node.Kind, node.Value})
+				visited = append(visited, []any{"leave", node.Kind, node.Value})
 				if node.Value == "x" {
 					return visitor.ActionBreak, nil
 				}
 			case ast.Node:
-				visited = append(visited, []interface{}{"leave", node.GetKind(), nil})
+				visited = append(visited, []any{"leave", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"leave", nil, nil})
+				visited = append(visited, []any{"leave", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
@@ -429,41 +429,41 @@ func TestVisitor_AllowsANamedFunctionsVisitorAPI(t *testing.T) {
 	query := `{ a, b { x }, c }`
 	astDoc := parse(t, query)
 
-	visited := []interface{}{}
-	expectedVisited := []interface{}{
-		[]interface{}{"enter", "SelectionSet", nil},
-		[]interface{}{"enter", "Name", "a"},
-		[]interface{}{"enter", "Name", "b"},
-		[]interface{}{"enter", "SelectionSet", nil},
-		[]interface{}{"enter", "Name", "x"},
-		[]interface{}{"leave", "SelectionSet", nil},
-		[]interface{}{"enter", "Name", "c"},
-		[]interface{}{"leave", "SelectionSet", nil},
+	visited := []any{}
+	expectedVisited := []any{
+		[]any{"enter", "SelectionSet", nil},
+		[]any{"enter", "Name", "a"},
+		[]any{"enter", "Name", "b"},
+		[]any{"enter", "SelectionSet", nil},
+		[]any{"enter", "Name", "x"},
+		[]any{"leave", "SelectionSet", nil},
+		[]any{"enter", "Name", "c"},
+		[]any{"leave", "SelectionSet", nil},
 	}
 
 	v := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			"Name": {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					switch node := p.Node.(type) {
 					case *ast.Name:
-						visited = append(visited, []interface{}{"enter", node.Kind, node.Value})
+						visited = append(visited, []any{"enter", node.Kind, node.Value})
 					}
 					return visitor.ActionNoChange, nil
 				},
 			},
 			"SelectionSet": {
-				Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Enter: func(p visitor.VisitFuncParams) (string, any) {
 					switch node := p.Node.(type) {
 					case *ast.SelectionSet:
-						visited = append(visited, []interface{}{"enter", node.Kind, nil})
+						visited = append(visited, []any{"enter", node.Kind, nil})
 					}
 					return visitor.ActionNoChange, nil
 				},
-				Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Leave: func(p visitor.VisitFuncParams) (string, any) {
 					switch node := p.Node.(type) {
 					case *ast.SelectionSet:
-						visited = append(visited, []interface{}{"leave", node.Kind, nil})
+						visited = append(visited, []any{"leave", node.Kind, nil})
 					}
 					return visitor.ActionNoChange, nil
 				},
@@ -486,331 +486,331 @@ func TestVisitor_VisitsKitchenSink(t *testing.T) {
 	query := string(b)
 	astDoc := parse(t, query)
 
-	visited := []interface{}{}
-	expectedVisited := []interface{}{
-		[]interface{}{"enter", "Document", nil, nil},
-		[]interface{}{"enter", "OperationDefinition", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "OperationDefinition"},
-		[]interface{}{"leave", "Name", "Name", "OperationDefinition"},
-		[]interface{}{"enter", "VariableDefinition", 0, nil},
-		[]interface{}{"enter", "Variable", "Variable", "VariableDefinition"},
-		[]interface{}{"enter", "Name", "Name", "Variable"},
-		[]interface{}{"leave", "Name", "Name", "Variable"},
-		[]interface{}{"leave", "Variable", "Variable", "VariableDefinition"},
-		[]interface{}{"enter", "Named", "Type", "VariableDefinition"},
-		[]interface{}{"enter", "Name", "Name", "Named"},
-		[]interface{}{"leave", "Name", "Name", "Named"},
-		[]interface{}{"leave", "Named", "Type", "VariableDefinition"},
-		[]interface{}{"leave", "VariableDefinition", 0, nil},
-		[]interface{}{"enter", "VariableDefinition", 1, nil},
-		[]interface{}{"enter", "Variable", "Variable", "VariableDefinition"},
-		[]interface{}{"enter", "Name", "Name", "Variable"},
-		[]interface{}{"leave", "Name", "Name", "Variable"},
-		[]interface{}{"leave", "Variable", "Variable", "VariableDefinition"},
-		[]interface{}{"enter", "Named", "Type", "VariableDefinition"},
-		[]interface{}{"enter", "Name", "Name", "Named"},
-		[]interface{}{"leave", "Name", "Name", "Named"},
-		[]interface{}{"leave", "Named", "Type", "VariableDefinition"},
-		[]interface{}{"enter", "EnumValue", "DefaultValue", "VariableDefinition"},
-		[]interface{}{"leave", "EnumValue", "DefaultValue", "VariableDefinition"},
-		[]interface{}{"leave", "VariableDefinition", 1, nil},
-		[]interface{}{"enter", "SelectionSet", "SelectionSet", "OperationDefinition"},
-		[]interface{}{"enter", "Field", 0, nil},
-		[]interface{}{"enter", "Name", "Alias", "Field"},
-		[]interface{}{"leave", "Name", "Alias", "Field"},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"enter", "Argument", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Argument"},
-		[]interface{}{"leave", "Name", "Name", "Argument"},
-		[]interface{}{"enter", "ListValue", "Value", "Argument"},
-		[]interface{}{"enter", "IntValue", 0, nil},
-		[]interface{}{"leave", "IntValue", 0, nil},
-		[]interface{}{"enter", "IntValue", 1, nil},
-		[]interface{}{"leave", "IntValue", 1, nil},
-		[]interface{}{"leave", "ListValue", "Value", "Argument"},
-		[]interface{}{"leave", "Argument", 0, nil},
-		[]interface{}{"enter", "SelectionSet", "SelectionSet", "Field"},
-		[]interface{}{"enter", "Field", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Field", 0, nil},
-		[]interface{}{"enter", "InlineFragment", 1, nil},
-		[]interface{}{"enter", "Named", "TypeCondition", "InlineFragment"},
-		[]interface{}{"enter", "Name", "Name", "Named"},
-		[]interface{}{"leave", "Name", "Name", "Named"},
-		[]interface{}{"leave", "Named", "TypeCondition", "InlineFragment"},
-		[]interface{}{"enter", "Directive", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Directive"},
-		[]interface{}{"leave", "Name", "Name", "Directive"},
-		[]interface{}{"leave", "Directive", 0, nil},
-		[]interface{}{"enter", "SelectionSet", "SelectionSet", "InlineFragment"},
+	visited := []any{}
+	expectedVisited := []any{
+		[]any{"enter", "Document", nil, nil},
+		[]any{"enter", "OperationDefinition", 0, nil},
+		[]any{"enter", "Name", "Name", "OperationDefinition"},
+		[]any{"leave", "Name", "Name", "OperationDefinition"},
+		[]any{"enter", "VariableDefinition", 0, nil},
+		[]any{"enter", "Variable", "Variable", "VariableDefinition"},
+		[]any{"enter", "Name", "Name", "Variable"},
+		[]any{"leave", "Name", "Name", "Variable"},
+		[]any{"leave", "Variable", "Variable", "VariableDefinition"},
+		[]any{"enter", "Named", "Type", "VariableDefinition"},
+		[]any{"enter", "Name", "Name", "Named"},
+		[]any{"leave", "Name", "Name", "Named"},
+		[]any{"leave", "Named", "Type", "VariableDefinition"},
+		[]any{"leave", "VariableDefinition", 0, nil},
+		[]any{"enter", "VariableDefinition", 1, nil},
+		[]any{"enter", "Variable", "Variable", "VariableDefinition"},
+		[]any{"enter", "Name", "Name", "Variable"},
+		[]any{"leave", "Name", "Name", "Variable"},
+		[]any{"leave", "Variable", "Variable", "VariableDefinition"},
+		[]any{"enter", "Named", "Type", "VariableDefinition"},
+		[]any{"enter", "Name", "Name", "Named"},
+		[]any{"leave", "Name", "Name", "Named"},
+		[]any{"leave", "Named", "Type", "VariableDefinition"},
+		[]any{"enter", "EnumValue", "DefaultValue", "VariableDefinition"},
+		[]any{"leave", "EnumValue", "DefaultValue", "VariableDefinition"},
+		[]any{"leave", "VariableDefinition", 1, nil},
+		[]any{"enter", "SelectionSet", "SelectionSet", "OperationDefinition"},
+		[]any{"enter", "Field", 0, nil},
+		[]any{"enter", "Name", "Alias", "Field"},
+		[]any{"leave", "Name", "Alias", "Field"},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"enter", "Argument", 0, nil},
+		[]any{"enter", "Name", "Name", "Argument"},
+		[]any{"leave", "Name", "Name", "Argument"},
+		[]any{"enter", "ListValue", "Value", "Argument"},
+		[]any{"enter", "IntValue", 0, nil},
+		[]any{"leave", "IntValue", 0, nil},
+		[]any{"enter", "IntValue", 1, nil},
+		[]any{"leave", "IntValue", 1, nil},
+		[]any{"leave", "ListValue", "Value", "Argument"},
+		[]any{"leave", "Argument", 0, nil},
+		[]any{"enter", "SelectionSet", "SelectionSet", "Field"},
+		[]any{"enter", "Field", 0, nil},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"leave", "Field", 0, nil},
+		[]any{"enter", "InlineFragment", 1, nil},
+		[]any{"enter", "Named", "TypeCondition", "InlineFragment"},
+		[]any{"enter", "Name", "Name", "Named"},
+		[]any{"leave", "Name", "Name", "Named"},
+		[]any{"leave", "Named", "TypeCondition", "InlineFragment"},
+		[]any{"enter", "Directive", 0, nil},
+		[]any{"enter", "Name", "Name", "Directive"},
+		[]any{"leave", "Name", "Name", "Directive"},
+		[]any{"leave", "Directive", 0, nil},
+		[]any{"enter", "SelectionSet", "SelectionSet", "InlineFragment"},
 
-		[]interface{}{"enter", "Field", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"enter", "SelectionSet", "SelectionSet", "Field"},
-		[]interface{}{"enter", "Field", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Field", 0, nil},
-		[]interface{}{"enter", "Field", 1, nil},
-		[]interface{}{"enter", "Name", "Alias", "Field"},
-		[]interface{}{"leave", "Name", "Alias", "Field"},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"enter", "Argument", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Argument"},
-		[]interface{}{"leave", "Name", "Name", "Argument"},
-		[]interface{}{"enter", "IntValue", "Value", "Argument"},
-		[]interface{}{"leave", "IntValue", "Value", "Argument"},
-		[]interface{}{"leave", "Argument", 0, nil},
-		[]interface{}{"enter", "Argument", 1, nil},
-		[]interface{}{"enter", "Name", "Name", "Argument"},
-		[]interface{}{"leave", "Name", "Name", "Argument"},
-		[]interface{}{"enter", "Variable", "Value", "Argument"},
-		[]interface{}{"enter", "Name", "Name", "Variable"},
-		[]interface{}{"leave", "Name", "Name", "Variable"},
-		[]interface{}{"leave", "Variable", "Value", "Argument"},
-		[]interface{}{"leave", "Argument", 1, nil},
-		[]interface{}{"enter", "Directive", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Directive"},
-		[]interface{}{"leave", "Name", "Name", "Directive"},
-		[]interface{}{"enter", "Argument", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Argument"},
-		[]interface{}{"leave", "Name", "Name", "Argument"},
-		[]interface{}{"enter", "Variable", "Value", "Argument"},
-		[]interface{}{"enter", "Name", "Name", "Variable"},
-		[]interface{}{"leave", "Name", "Name", "Variable"},
-		[]interface{}{"leave", "Variable", "Value", "Argument"},
-		[]interface{}{"leave", "Argument", 0, nil},
-		[]interface{}{"leave", "Directive", 0, nil},
-		[]interface{}{"enter", "SelectionSet", "SelectionSet", "Field"},
-		[]interface{}{"enter", "Field", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Field", 0, nil},
-		[]interface{}{"enter", "FragmentSpread", 1, nil},
-		[]interface{}{"enter", "Name", "Name", "FragmentSpread"},
-		[]interface{}{"leave", "Name", "Name", "FragmentSpread"},
-		[]interface{}{"leave", "FragmentSpread", 1, nil},
-		[]interface{}{"leave", "SelectionSet", "SelectionSet", "Field"},
-		[]interface{}{"leave", "Field", 1, nil},
-		[]interface{}{"leave", "SelectionSet", "SelectionSet", "Field"},
-		[]interface{}{"leave", "Field", 0, nil},
-		[]interface{}{"leave", "SelectionSet", "SelectionSet", "InlineFragment"},
-		[]interface{}{"leave", "InlineFragment", 1, nil},
-		[]interface{}{"enter", "InlineFragment", 2, nil},
-		[]interface{}{"enter", "Directive", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Directive"},
-		[]interface{}{"leave", "Name", "Name", "Directive"},
-		[]interface{}{"enter", "Argument", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Argument"},
-		[]interface{}{"leave", "Name", "Name", "Argument"},
-		[]interface{}{"enter", "Variable", "Value", "Argument"},
-		[]interface{}{"enter", "Name", "Name", "Variable"},
-		[]interface{}{"leave", "Name", "Name", "Variable"},
+		[]any{"enter", "Field", 0, nil},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"enter", "SelectionSet", "SelectionSet", "Field"},
+		[]any{"enter", "Field", 0, nil},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"leave", "Field", 0, nil},
+		[]any{"enter", "Field", 1, nil},
+		[]any{"enter", "Name", "Alias", "Field"},
+		[]any{"leave", "Name", "Alias", "Field"},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"enter", "Argument", 0, nil},
+		[]any{"enter", "Name", "Name", "Argument"},
+		[]any{"leave", "Name", "Name", "Argument"},
+		[]any{"enter", "IntValue", "Value", "Argument"},
+		[]any{"leave", "IntValue", "Value", "Argument"},
+		[]any{"leave", "Argument", 0, nil},
+		[]any{"enter", "Argument", 1, nil},
+		[]any{"enter", "Name", "Name", "Argument"},
+		[]any{"leave", "Name", "Name", "Argument"},
+		[]any{"enter", "Variable", "Value", "Argument"},
+		[]any{"enter", "Name", "Name", "Variable"},
+		[]any{"leave", "Name", "Name", "Variable"},
+		[]any{"leave", "Variable", "Value", "Argument"},
+		[]any{"leave", "Argument", 1, nil},
+		[]any{"enter", "Directive", 0, nil},
+		[]any{"enter", "Name", "Name", "Directive"},
+		[]any{"leave", "Name", "Name", "Directive"},
+		[]any{"enter", "Argument", 0, nil},
+		[]any{"enter", "Name", "Name", "Argument"},
+		[]any{"leave", "Name", "Name", "Argument"},
+		[]any{"enter", "Variable", "Value", "Argument"},
+		[]any{"enter", "Name", "Name", "Variable"},
+		[]any{"leave", "Name", "Name", "Variable"},
+		[]any{"leave", "Variable", "Value", "Argument"},
+		[]any{"leave", "Argument", 0, nil},
+		[]any{"leave", "Directive", 0, nil},
+		[]any{"enter", "SelectionSet", "SelectionSet", "Field"},
+		[]any{"enter", "Field", 0, nil},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"leave", "Field", 0, nil},
+		[]any{"enter", "FragmentSpread", 1, nil},
+		[]any{"enter", "Name", "Name", "FragmentSpread"},
+		[]any{"leave", "Name", "Name", "FragmentSpread"},
+		[]any{"leave", "FragmentSpread", 1, nil},
+		[]any{"leave", "SelectionSet", "SelectionSet", "Field"},
+		[]any{"leave", "Field", 1, nil},
+		[]any{"leave", "SelectionSet", "SelectionSet", "Field"},
+		[]any{"leave", "Field", 0, nil},
+		[]any{"leave", "SelectionSet", "SelectionSet", "InlineFragment"},
+		[]any{"leave", "InlineFragment", 1, nil},
+		[]any{"enter", "InlineFragment", 2, nil},
+		[]any{"enter", "Directive", 0, nil},
+		[]any{"enter", "Name", "Name", "Directive"},
+		[]any{"leave", "Name", "Name", "Directive"},
+		[]any{"enter", "Argument", 0, nil},
+		[]any{"enter", "Name", "Name", "Argument"},
+		[]any{"leave", "Name", "Name", "Argument"},
+		[]any{"enter", "Variable", "Value", "Argument"},
+		[]any{"enter", "Name", "Name", "Variable"},
+		[]any{"leave", "Name", "Name", "Variable"},
 
-		[]interface{}{"leave", "Variable", "Value", "Argument"},
-		[]interface{}{"leave", "Argument", 0, nil},
-		[]interface{}{"leave", "Directive", 0, nil},
-		[]interface{}{"enter", "SelectionSet", "SelectionSet", "InlineFragment"},
-		[]interface{}{"enter", "Field", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Field", 0, nil},
-		[]interface{}{"leave", "SelectionSet", "SelectionSet", "InlineFragment"},
-		[]interface{}{"leave", "InlineFragment", 2, nil},
-		[]interface{}{"enter", "InlineFragment", 3, nil},
-		[]interface{}{"enter", "SelectionSet", "SelectionSet", "InlineFragment"},
-		[]interface{}{"enter", "Field", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Field", 0, nil},
-		[]interface{}{"leave", "SelectionSet", "SelectionSet", "InlineFragment"},
-		[]interface{}{"leave", "InlineFragment", 3, nil},
-		[]interface{}{"leave", "SelectionSet", "SelectionSet", "Field"},
-		[]interface{}{"leave", "Field", 0, nil},
-		[]interface{}{"leave", "SelectionSet", "SelectionSet", "OperationDefinition"},
-		[]interface{}{"leave", "OperationDefinition", 0, nil},
-		[]interface{}{"enter", "OperationDefinition", 1, nil},
-		[]interface{}{"enter", "Name", "Name", "OperationDefinition"},
-		[]interface{}{"leave", "Name", "Name", "OperationDefinition"},
-		[]interface{}{"enter", "SelectionSet", "SelectionSet", "OperationDefinition"},
-		[]interface{}{"enter", "Field", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"enter", "Argument", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Argument"},
-		[]interface{}{"leave", "Name", "Name", "Argument"},
-		[]interface{}{"enter", "IntValue", "Value", "Argument"},
-		[]interface{}{"leave", "IntValue", "Value", "Argument"},
-		[]interface{}{"leave", "Argument", 0, nil},
-		[]interface{}{"enter", "Directive", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Directive"},
-		[]interface{}{"leave", "Name", "Name", "Directive"},
-		[]interface{}{"leave", "Directive", 0, nil},
-		[]interface{}{"enter", "SelectionSet", "SelectionSet", "Field"},
-		[]interface{}{"enter", "Field", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"enter", "SelectionSet", "SelectionSet", "Field"},
-		[]interface{}{"enter", "Field", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Field", 0, nil},
-		[]interface{}{"leave", "SelectionSet", "SelectionSet", "Field"},
-		[]interface{}{"leave", "Field", 0, nil},
-		[]interface{}{"leave", "SelectionSet", "SelectionSet", "Field"},
-		[]interface{}{"leave", "Field", 0, nil},
-		[]interface{}{"leave", "SelectionSet", "SelectionSet", "OperationDefinition"},
-		[]interface{}{"leave", "OperationDefinition", 1, nil},
-		[]interface{}{"enter", "OperationDefinition", 2, nil},
-		[]interface{}{"enter", "Name", "Name", "OperationDefinition"},
-		[]interface{}{"leave", "Name", "Name", "OperationDefinition"},
-		[]interface{}{"enter", "VariableDefinition", 0, nil},
-		[]interface{}{"enter", "Variable", "Variable", "VariableDefinition"},
-		[]interface{}{"enter", "Name", "Name", "Variable"},
-		[]interface{}{"leave", "Name", "Name", "Variable"},
+		[]any{"leave", "Variable", "Value", "Argument"},
+		[]any{"leave", "Argument", 0, nil},
+		[]any{"leave", "Directive", 0, nil},
+		[]any{"enter", "SelectionSet", "SelectionSet", "InlineFragment"},
+		[]any{"enter", "Field", 0, nil},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"leave", "Field", 0, nil},
+		[]any{"leave", "SelectionSet", "SelectionSet", "InlineFragment"},
+		[]any{"leave", "InlineFragment", 2, nil},
+		[]any{"enter", "InlineFragment", 3, nil},
+		[]any{"enter", "SelectionSet", "SelectionSet", "InlineFragment"},
+		[]any{"enter", "Field", 0, nil},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"leave", "Field", 0, nil},
+		[]any{"leave", "SelectionSet", "SelectionSet", "InlineFragment"},
+		[]any{"leave", "InlineFragment", 3, nil},
+		[]any{"leave", "SelectionSet", "SelectionSet", "Field"},
+		[]any{"leave", "Field", 0, nil},
+		[]any{"leave", "SelectionSet", "SelectionSet", "OperationDefinition"},
+		[]any{"leave", "OperationDefinition", 0, nil},
+		[]any{"enter", "OperationDefinition", 1, nil},
+		[]any{"enter", "Name", "Name", "OperationDefinition"},
+		[]any{"leave", "Name", "Name", "OperationDefinition"},
+		[]any{"enter", "SelectionSet", "SelectionSet", "OperationDefinition"},
+		[]any{"enter", "Field", 0, nil},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"enter", "Argument", 0, nil},
+		[]any{"enter", "Name", "Name", "Argument"},
+		[]any{"leave", "Name", "Name", "Argument"},
+		[]any{"enter", "IntValue", "Value", "Argument"},
+		[]any{"leave", "IntValue", "Value", "Argument"},
+		[]any{"leave", "Argument", 0, nil},
+		[]any{"enter", "Directive", 0, nil},
+		[]any{"enter", "Name", "Name", "Directive"},
+		[]any{"leave", "Name", "Name", "Directive"},
+		[]any{"leave", "Directive", 0, nil},
+		[]any{"enter", "SelectionSet", "SelectionSet", "Field"},
+		[]any{"enter", "Field", 0, nil},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"enter", "SelectionSet", "SelectionSet", "Field"},
+		[]any{"enter", "Field", 0, nil},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"leave", "Field", 0, nil},
+		[]any{"leave", "SelectionSet", "SelectionSet", "Field"},
+		[]any{"leave", "Field", 0, nil},
+		[]any{"leave", "SelectionSet", "SelectionSet", "Field"},
+		[]any{"leave", "Field", 0, nil},
+		[]any{"leave", "SelectionSet", "SelectionSet", "OperationDefinition"},
+		[]any{"leave", "OperationDefinition", 1, nil},
+		[]any{"enter", "OperationDefinition", 2, nil},
+		[]any{"enter", "Name", "Name", "OperationDefinition"},
+		[]any{"leave", "Name", "Name", "OperationDefinition"},
+		[]any{"enter", "VariableDefinition", 0, nil},
+		[]any{"enter", "Variable", "Variable", "VariableDefinition"},
+		[]any{"enter", "Name", "Name", "Variable"},
+		[]any{"leave", "Name", "Name", "Variable"},
 
-		[]interface{}{"leave", "Variable", "Variable", "VariableDefinition"},
-		[]interface{}{"enter", "Named", "Type", "VariableDefinition"},
-		[]interface{}{"enter", "Name", "Name", "Named"},
-		[]interface{}{"leave", "Name", "Name", "Named"},
-		[]interface{}{"leave", "Named", "Type", "VariableDefinition"},
-		[]interface{}{"leave", "VariableDefinition", 0, nil},
-		[]interface{}{"enter", "SelectionSet", "SelectionSet", "OperationDefinition"},
-		[]interface{}{"enter", "Field", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"enter", "Argument", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Argument"},
-		[]interface{}{"leave", "Name", "Name", "Argument"},
-		[]interface{}{"enter", "Variable", "Value", "Argument"},
-		[]interface{}{"enter", "Name", "Name", "Variable"},
-		[]interface{}{"leave", "Name", "Name", "Variable"},
-		[]interface{}{"leave", "Variable", "Value", "Argument"},
-		[]interface{}{"leave", "Argument", 0, nil},
-		[]interface{}{"enter", "SelectionSet", "SelectionSet", "Field"},
-		[]interface{}{"enter", "Field", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"enter", "SelectionSet", "SelectionSet", "Field"},
-		[]interface{}{"enter", "Field", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"enter", "SelectionSet", "SelectionSet", "Field"},
-		[]interface{}{"enter", "Field", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Field", 0, nil},
-		[]interface{}{"leave", "SelectionSet", "SelectionSet", "Field"},
-		[]interface{}{"leave", "Field", 0, nil},
-		[]interface{}{"enter", "Field", 1, nil},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"enter", "SelectionSet", "SelectionSet", "Field"},
-		[]interface{}{"enter", "Field", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Field", 0, nil},
-		[]interface{}{"leave", "SelectionSet", "SelectionSet", "Field"},
-		[]interface{}{"leave", "Field", 1, nil},
-		[]interface{}{"leave", "SelectionSet", "SelectionSet", "Field"},
-		[]interface{}{"leave", "Field", 0, nil},
-		[]interface{}{"leave", "SelectionSet", "SelectionSet", "Field"},
-		[]interface{}{"leave", "Field", 0, nil},
-		[]interface{}{"leave", "SelectionSet", "SelectionSet", "OperationDefinition"},
-		[]interface{}{"leave", "OperationDefinition", 2, nil},
-		[]interface{}{"enter", "FragmentDefinition", 3, nil},
-		[]interface{}{"enter", "Name", "Name", "FragmentDefinition"},
-		[]interface{}{"leave", "Name", "Name", "FragmentDefinition"},
-		[]interface{}{"enter", "Named", "TypeCondition", "FragmentDefinition"},
-		[]interface{}{"enter", "Name", "Name", "Named"},
-		[]interface{}{"leave", "Name", "Name", "Named"},
-		[]interface{}{"leave", "Named", "TypeCondition", "FragmentDefinition"},
-		[]interface{}{"enter", "SelectionSet", "SelectionSet", "FragmentDefinition"},
-		[]interface{}{"enter", "Field", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"enter", "Argument", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Argument"},
-		[]interface{}{"leave", "Name", "Name", "Argument"},
+		[]any{"leave", "Variable", "Variable", "VariableDefinition"},
+		[]any{"enter", "Named", "Type", "VariableDefinition"},
+		[]any{"enter", "Name", "Name", "Named"},
+		[]any{"leave", "Name", "Name", "Named"},
+		[]any{"leave", "Named", "Type", "VariableDefinition"},
+		[]any{"leave", "VariableDefinition", 0, nil},
+		[]any{"enter", "SelectionSet", "SelectionSet", "OperationDefinition"},
+		[]any{"enter", "Field", 0, nil},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"enter", "Argument", 0, nil},
+		[]any{"enter", "Name", "Name", "Argument"},
+		[]any{"leave", "Name", "Name", "Argument"},
+		[]any{"enter", "Variable", "Value", "Argument"},
+		[]any{"enter", "Name", "Name", "Variable"},
+		[]any{"leave", "Name", "Name", "Variable"},
+		[]any{"leave", "Variable", "Value", "Argument"},
+		[]any{"leave", "Argument", 0, nil},
+		[]any{"enter", "SelectionSet", "SelectionSet", "Field"},
+		[]any{"enter", "Field", 0, nil},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"enter", "SelectionSet", "SelectionSet", "Field"},
+		[]any{"enter", "Field", 0, nil},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"enter", "SelectionSet", "SelectionSet", "Field"},
+		[]any{"enter", "Field", 0, nil},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"leave", "Field", 0, nil},
+		[]any{"leave", "SelectionSet", "SelectionSet", "Field"},
+		[]any{"leave", "Field", 0, nil},
+		[]any{"enter", "Field", 1, nil},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"enter", "SelectionSet", "SelectionSet", "Field"},
+		[]any{"enter", "Field", 0, nil},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"leave", "Field", 0, nil},
+		[]any{"leave", "SelectionSet", "SelectionSet", "Field"},
+		[]any{"leave", "Field", 1, nil},
+		[]any{"leave", "SelectionSet", "SelectionSet", "Field"},
+		[]any{"leave", "Field", 0, nil},
+		[]any{"leave", "SelectionSet", "SelectionSet", "Field"},
+		[]any{"leave", "Field", 0, nil},
+		[]any{"leave", "SelectionSet", "SelectionSet", "OperationDefinition"},
+		[]any{"leave", "OperationDefinition", 2, nil},
+		[]any{"enter", "FragmentDefinition", 3, nil},
+		[]any{"enter", "Name", "Name", "FragmentDefinition"},
+		[]any{"leave", "Name", "Name", "FragmentDefinition"},
+		[]any{"enter", "Named", "TypeCondition", "FragmentDefinition"},
+		[]any{"enter", "Name", "Name", "Named"},
+		[]any{"leave", "Name", "Name", "Named"},
+		[]any{"leave", "Named", "TypeCondition", "FragmentDefinition"},
+		[]any{"enter", "SelectionSet", "SelectionSet", "FragmentDefinition"},
+		[]any{"enter", "Field", 0, nil},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"enter", "Argument", 0, nil},
+		[]any{"enter", "Name", "Name", "Argument"},
+		[]any{"leave", "Name", "Name", "Argument"},
 
-		[]interface{}{"enter", "Variable", "Value", "Argument"},
-		[]interface{}{"enter", "Name", "Name", "Variable"},
-		[]interface{}{"leave", "Name", "Name", "Variable"},
-		[]interface{}{"leave", "Variable", "Value", "Argument"},
-		[]interface{}{"leave", "Argument", 0, nil},
-		[]interface{}{"enter", "Argument", 1, nil},
-		[]interface{}{"enter", "Name", "Name", "Argument"},
-		[]interface{}{"leave", "Name", "Name", "Argument"},
-		[]interface{}{"enter", "Variable", "Value", "Argument"},
-		[]interface{}{"enter", "Name", "Name", "Variable"},
-		[]interface{}{"leave", "Name", "Name", "Variable"},
-		[]interface{}{"leave", "Variable", "Value", "Argument"},
-		[]interface{}{"leave", "Argument", 1, nil},
-		[]interface{}{"enter", "Argument", 2, nil},
-		[]interface{}{"enter", "Name", "Name", "Argument"},
-		[]interface{}{"leave", "Name", "Name", "Argument"},
-		[]interface{}{"enter", "ObjectValue", "Value", "Argument"},
-		[]interface{}{"enter", "ObjectField", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "ObjectField"},
-		[]interface{}{"leave", "Name", "Name", "ObjectField"},
-		[]interface{}{"enter", "StringValue", "Value", "ObjectField"},
-		[]interface{}{"leave", "StringValue", "Value", "ObjectField"},
-		[]interface{}{"leave", "ObjectField", 0, nil},
-		[]interface{}{"leave", "ObjectValue", "Value", "Argument"},
-		[]interface{}{"leave", "Argument", 2, nil},
-		[]interface{}{"leave", "Field", 0, nil},
-		[]interface{}{"leave", "SelectionSet", "SelectionSet", "FragmentDefinition"},
-		[]interface{}{"leave", "FragmentDefinition", 3, nil},
-		[]interface{}{"enter", "OperationDefinition", 4, nil},
-		[]interface{}{"enter", "SelectionSet", "SelectionSet", "OperationDefinition"},
-		[]interface{}{"enter", "Field", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"enter", "Argument", 0, nil},
-		[]interface{}{"enter", "Name", "Name", "Argument"},
-		[]interface{}{"leave", "Name", "Name", "Argument"},
-		[]interface{}{"enter", "BooleanValue", "Value", "Argument"},
-		[]interface{}{"leave", "BooleanValue", "Value", "Argument"},
-		[]interface{}{"leave", "Argument", 0, nil},
-		[]interface{}{"enter", "Argument", 1, nil},
-		[]interface{}{"enter", "Name", "Name", "Argument"},
-		[]interface{}{"leave", "Name", "Name", "Argument"},
-		[]interface{}{"enter", "BooleanValue", "Value", "Argument"},
-		[]interface{}{"leave", "BooleanValue", "Value", "Argument"},
-		[]interface{}{"leave", "Argument", 1, nil},
-		[]interface{}{"leave", "Field", 0, nil},
-		[]interface{}{"enter", "Field", 1, nil},
-		[]interface{}{"enter", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Name", "Name", "Field"},
-		[]interface{}{"leave", "Field", 1, nil},
-		[]interface{}{"leave", "SelectionSet", "SelectionSet", "OperationDefinition"},
-		[]interface{}{"leave", "OperationDefinition", 4, nil},
-		[]interface{}{"leave", "Document", nil, nil},
+		[]any{"enter", "Variable", "Value", "Argument"},
+		[]any{"enter", "Name", "Name", "Variable"},
+		[]any{"leave", "Name", "Name", "Variable"},
+		[]any{"leave", "Variable", "Value", "Argument"},
+		[]any{"leave", "Argument", 0, nil},
+		[]any{"enter", "Argument", 1, nil},
+		[]any{"enter", "Name", "Name", "Argument"},
+		[]any{"leave", "Name", "Name", "Argument"},
+		[]any{"enter", "Variable", "Value", "Argument"},
+		[]any{"enter", "Name", "Name", "Variable"},
+		[]any{"leave", "Name", "Name", "Variable"},
+		[]any{"leave", "Variable", "Value", "Argument"},
+		[]any{"leave", "Argument", 1, nil},
+		[]any{"enter", "Argument", 2, nil},
+		[]any{"enter", "Name", "Name", "Argument"},
+		[]any{"leave", "Name", "Name", "Argument"},
+		[]any{"enter", "ObjectValue", "Value", "Argument"},
+		[]any{"enter", "ObjectField", 0, nil},
+		[]any{"enter", "Name", "Name", "ObjectField"},
+		[]any{"leave", "Name", "Name", "ObjectField"},
+		[]any{"enter", "StringValue", "Value", "ObjectField"},
+		[]any{"leave", "StringValue", "Value", "ObjectField"},
+		[]any{"leave", "ObjectField", 0, nil},
+		[]any{"leave", "ObjectValue", "Value", "Argument"},
+		[]any{"leave", "Argument", 2, nil},
+		[]any{"leave", "Field", 0, nil},
+		[]any{"leave", "SelectionSet", "SelectionSet", "FragmentDefinition"},
+		[]any{"leave", "FragmentDefinition", 3, nil},
+		[]any{"enter", "OperationDefinition", 4, nil},
+		[]any{"enter", "SelectionSet", "SelectionSet", "OperationDefinition"},
+		[]any{"enter", "Field", 0, nil},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"enter", "Argument", 0, nil},
+		[]any{"enter", "Name", "Name", "Argument"},
+		[]any{"leave", "Name", "Name", "Argument"},
+		[]any{"enter", "BooleanValue", "Value", "Argument"},
+		[]any{"leave", "BooleanValue", "Value", "Argument"},
+		[]any{"leave", "Argument", 0, nil},
+		[]any{"enter", "Argument", 1, nil},
+		[]any{"enter", "Name", "Name", "Argument"},
+		[]any{"leave", "Name", "Name", "Argument"},
+		[]any{"enter", "BooleanValue", "Value", "Argument"},
+		[]any{"leave", "BooleanValue", "Value", "Argument"},
+		[]any{"leave", "Argument", 1, nil},
+		[]any{"leave", "Field", 0, nil},
+		[]any{"enter", "Field", 1, nil},
+		[]any{"enter", "Name", "Name", "Field"},
+		[]any{"leave", "Name", "Name", "Field"},
+		[]any{"leave", "Field", 1, nil},
+		[]any{"leave", "SelectionSet", "SelectionSet", "OperationDefinition"},
+		[]any{"leave", "OperationDefinition", 4, nil},
+		[]any{"leave", "Document", nil, nil},
 	}
 
 	v := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case ast.Node:
 				if p.Parent != nil {
-					visited = append(visited, []interface{}{"enter", node.GetKind(), p.Key, p.Parent.GetKind()})
+					visited = append(visited, []any{"enter", node.GetKind(), p.Key, p.Parent.GetKind()})
 				} else {
-					visited = append(visited, []interface{}{"enter", node.GetKind(), p.Key, nil})
+					visited = append(visited, []any{"enter", node.GetKind(), p.Key, nil})
 				}
 			}
 			return visitor.ActionNoChange, nil
 		},
-		Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Leave: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case ast.Node:
 				if p.Parent != nil {
-					visited = append(visited, []interface{}{"leave", node.GetKind(), p.Key, p.Parent.GetKind()})
+					visited = append(visited, []any{"leave", node.GetKind(), p.Key, p.Parent.GetKind()})
 				} else {
-					visited = append(visited, []interface{}{"leave", node.GetKind(), p.Key, nil})
+					visited = append(visited, []any{"leave", node.GetKind(), p.Key, nil})
 				}
 			}
 			return visitor.ActionNoChange, nil
@@ -832,50 +832,50 @@ func TestVisitor_VisitInParallel_AllowsSkippingASubTree(t *testing.T) {
 	query := `{ a, b { x }, c }`
 	astDoc := parse(t, query)
 
-	visited := []interface{}{}
-	expectedVisited := []interface{}{
-		[]interface{}{"enter", "Document", nil},
-		[]interface{}{"enter", "OperationDefinition", nil},
-		[]interface{}{"enter", "SelectionSet", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "a"},
-		[]interface{}{"leave", "Name", "a"},
-		[]interface{}{"leave", "Field", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "c"},
-		[]interface{}{"leave", "Name", "c"},
-		[]interface{}{"leave", "Field", nil},
-		[]interface{}{"leave", "SelectionSet", nil},
-		[]interface{}{"leave", "OperationDefinition", nil},
-		[]interface{}{"leave", "Document", nil},
+	visited := []any{}
+	expectedVisited := []any{
+		[]any{"enter", "Document", nil},
+		[]any{"enter", "OperationDefinition", nil},
+		[]any{"enter", "SelectionSet", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "a"},
+		[]any{"leave", "Name", "a"},
+		[]any{"leave", "Field", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "c"},
+		[]any{"leave", "Name", "c"},
+		[]any{"leave", "Field", nil},
+		[]any{"leave", "SelectionSet", nil},
+		[]any{"leave", "OperationDefinition", nil},
+		[]any{"leave", "Document", nil},
 	}
 
 	v := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"enter", node.Kind, node.Value})
+				visited = append(visited, []any{"enter", node.Kind, node.Value})
 			case *ast.Field:
-				visited = append(visited, []interface{}{"enter", node.Kind, nil})
+				visited = append(visited, []any{"enter", node.Kind, nil})
 				if node.Name != nil && node.Name.Value == "b" {
 					return visitor.ActionSkip, nil
 				}
 			case ast.Node:
-				visited = append(visited, []interface{}{"enter", node.GetKind(), nil})
+				visited = append(visited, []any{"enter", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"enter", nil, nil})
+				visited = append(visited, []any{"enter", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
-		Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Leave: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"leave", node.Kind, node.Value})
+				visited = append(visited, []any{"leave", node.Kind, node.Value})
 			case ast.Node:
-				visited = append(visited, []interface{}{"leave", node.GetKind(), nil})
+				visited = append(visited, []any{"leave", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"leave", nil, nil})
+				visited = append(visited, []any{"leave", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
@@ -893,99 +893,99 @@ func TestVisitor_VisitInParallel_AllowsSkippingDifferentSubTrees(t *testing.T) {
 	query := `{ a { x }, b { y} }`
 	astDoc := parse(t, query)
 
-	visited := []interface{}{}
-	expectedVisited := []interface{}{
-		[]interface{}{"no-a", "enter", "Document", nil},
-		[]interface{}{"no-b", "enter", "Document", nil},
-		[]interface{}{"no-a", "enter", "OperationDefinition", nil},
-		[]interface{}{"no-b", "enter", "OperationDefinition", nil},
-		[]interface{}{"no-a", "enter", "SelectionSet", nil},
-		[]interface{}{"no-b", "enter", "SelectionSet", nil},
-		[]interface{}{"no-a", "enter", "Field", nil},
-		[]interface{}{"no-b", "enter", "Field", nil},
-		[]interface{}{"no-b", "enter", "Name", "a"},
-		[]interface{}{"no-b", "leave", "Name", "a"},
-		[]interface{}{"no-b", "enter", "SelectionSet", nil},
-		[]interface{}{"no-b", "enter", "Field", nil},
-		[]interface{}{"no-b", "enter", "Name", "x"},
-		[]interface{}{"no-b", "leave", "Name", "x"},
-		[]interface{}{"no-b", "leave", "Field", nil},
-		[]interface{}{"no-b", "leave", "SelectionSet", nil},
-		[]interface{}{"no-b", "leave", "Field", nil},
-		[]interface{}{"no-a", "enter", "Field", nil},
-		[]interface{}{"no-b", "enter", "Field", nil},
-		[]interface{}{"no-a", "enter", "Name", "b"},
-		[]interface{}{"no-a", "leave", "Name", "b"},
-		[]interface{}{"no-a", "enter", "SelectionSet", nil},
-		[]interface{}{"no-a", "enter", "Field", nil},
-		[]interface{}{"no-a", "enter", "Name", "y"},
-		[]interface{}{"no-a", "leave", "Name", "y"},
-		[]interface{}{"no-a", "leave", "Field", nil},
-		[]interface{}{"no-a", "leave", "SelectionSet", nil},
-		[]interface{}{"no-a", "leave", "Field", nil},
-		[]interface{}{"no-a", "leave", "SelectionSet", nil},
-		[]interface{}{"no-b", "leave", "SelectionSet", nil},
-		[]interface{}{"no-a", "leave", "OperationDefinition", nil},
-		[]interface{}{"no-b", "leave", "OperationDefinition", nil},
-		[]interface{}{"no-a", "leave", "Document", nil},
-		[]interface{}{"no-b", "leave", "Document", nil},
+	visited := []any{}
+	expectedVisited := []any{
+		[]any{"no-a", "enter", "Document", nil},
+		[]any{"no-b", "enter", "Document", nil},
+		[]any{"no-a", "enter", "OperationDefinition", nil},
+		[]any{"no-b", "enter", "OperationDefinition", nil},
+		[]any{"no-a", "enter", "SelectionSet", nil},
+		[]any{"no-b", "enter", "SelectionSet", nil},
+		[]any{"no-a", "enter", "Field", nil},
+		[]any{"no-b", "enter", "Field", nil},
+		[]any{"no-b", "enter", "Name", "a"},
+		[]any{"no-b", "leave", "Name", "a"},
+		[]any{"no-b", "enter", "SelectionSet", nil},
+		[]any{"no-b", "enter", "Field", nil},
+		[]any{"no-b", "enter", "Name", "x"},
+		[]any{"no-b", "leave", "Name", "x"},
+		[]any{"no-b", "leave", "Field", nil},
+		[]any{"no-b", "leave", "SelectionSet", nil},
+		[]any{"no-b", "leave", "Field", nil},
+		[]any{"no-a", "enter", "Field", nil},
+		[]any{"no-b", "enter", "Field", nil},
+		[]any{"no-a", "enter", "Name", "b"},
+		[]any{"no-a", "leave", "Name", "b"},
+		[]any{"no-a", "enter", "SelectionSet", nil},
+		[]any{"no-a", "enter", "Field", nil},
+		[]any{"no-a", "enter", "Name", "y"},
+		[]any{"no-a", "leave", "Name", "y"},
+		[]any{"no-a", "leave", "Field", nil},
+		[]any{"no-a", "leave", "SelectionSet", nil},
+		[]any{"no-a", "leave", "Field", nil},
+		[]any{"no-a", "leave", "SelectionSet", nil},
+		[]any{"no-b", "leave", "SelectionSet", nil},
+		[]any{"no-a", "leave", "OperationDefinition", nil},
+		[]any{"no-b", "leave", "OperationDefinition", nil},
+		[]any{"no-a", "leave", "Document", nil},
+		[]any{"no-b", "leave", "Document", nil},
 	}
 
 	v := []*visitor.VisitorOptions{
 		{
-			Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+			Enter: func(p visitor.VisitFuncParams) (string, any) {
 				switch node := p.Node.(type) {
 				case *ast.Name:
-					visited = append(visited, []interface{}{"no-a", "enter", node.Kind, node.Value})
+					visited = append(visited, []any{"no-a", "enter", node.Kind, node.Value})
 				case *ast.Field:
-					visited = append(visited, []interface{}{"no-a", "enter", node.Kind, nil})
+					visited = append(visited, []any{"no-a", "enter", node.Kind, nil})
 					if node.Name != nil && node.Name.Value == "a" {
 						return visitor.ActionSkip, nil
 					}
 				case ast.Node:
-					visited = append(visited, []interface{}{"no-a", "enter", node.GetKind(), nil})
+					visited = append(visited, []any{"no-a", "enter", node.GetKind(), nil})
 				default:
-					visited = append(visited, []interface{}{"no-a", "enter", nil, nil})
+					visited = append(visited, []any{"no-a", "enter", nil, nil})
 				}
 				return visitor.ActionNoChange, nil
 			},
-			Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+			Leave: func(p visitor.VisitFuncParams) (string, any) {
 				switch node := p.Node.(type) {
 				case *ast.Name:
-					visited = append(visited, []interface{}{"no-a", "leave", node.Kind, node.Value})
+					visited = append(visited, []any{"no-a", "leave", node.Kind, node.Value})
 				case ast.Node:
-					visited = append(visited, []interface{}{"no-a", "leave", node.GetKind(), nil})
+					visited = append(visited, []any{"no-a", "leave", node.GetKind(), nil})
 				default:
-					visited = append(visited, []interface{}{"no-a", "leave", nil, nil})
+					visited = append(visited, []any{"no-a", "leave", nil, nil})
 				}
 				return visitor.ActionNoChange, nil
 			},
 		},
 		{
-			Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+			Enter: func(p visitor.VisitFuncParams) (string, any) {
 				switch node := p.Node.(type) {
 				case *ast.Name:
-					visited = append(visited, []interface{}{"no-b", "enter", node.Kind, node.Value})
+					visited = append(visited, []any{"no-b", "enter", node.Kind, node.Value})
 				case *ast.Field:
-					visited = append(visited, []interface{}{"no-b", "enter", node.Kind, nil})
+					visited = append(visited, []any{"no-b", "enter", node.Kind, nil})
 					if node.Name != nil && node.Name.Value == "b" {
 						return visitor.ActionSkip, nil
 					}
 				case ast.Node:
-					visited = append(visited, []interface{}{"no-b", "enter", node.GetKind(), nil})
+					visited = append(visited, []any{"no-b", "enter", node.GetKind(), nil})
 				default:
-					visited = append(visited, []interface{}{"no-b", "enter", nil, nil})
+					visited = append(visited, []any{"no-b", "enter", nil, nil})
 				}
 				return visitor.ActionNoChange, nil
 			},
-			Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+			Leave: func(p visitor.VisitFuncParams) (string, any) {
 				switch node := p.Node.(type) {
 				case *ast.Name:
-					visited = append(visited, []interface{}{"no-b", "leave", node.Kind, node.Value})
+					visited = append(visited, []any{"no-b", "leave", node.Kind, node.Value})
 				case ast.Node:
-					visited = append(visited, []interface{}{"no-b", "leave", node.GetKind(), nil})
+					visited = append(visited, []any{"no-b", "leave", node.GetKind(), nil})
 				default:
-					visited = append(visited, []interface{}{"no-b", "leave", nil, nil})
+					visited = append(visited, []any{"no-b", "leave", nil, nil})
 				}
 				return visitor.ActionNoChange, nil
 			},
@@ -1004,50 +1004,50 @@ func TestVisitor_VisitInParallel_AllowsEarlyExitWhileVisiting(t *testing.T) {
 	// Note: nearly identical to the above test of the same test but
 	// using visitInParallel.
 
-	visited := []interface{}{}
+	visited := []any{}
 
 	query := `{ a, b { x }, c }`
 	astDoc := parse(t, query)
 
-	expectedVisited := []interface{}{
-		[]interface{}{"enter", "Document", nil},
-		[]interface{}{"enter", "OperationDefinition", nil},
-		[]interface{}{"enter", "SelectionSet", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "a"},
-		[]interface{}{"leave", "Name", "a"},
-		[]interface{}{"leave", "Field", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "b"},
-		[]interface{}{"leave", "Name", "b"},
-		[]interface{}{"enter", "SelectionSet", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "x"},
+	expectedVisited := []any{
+		[]any{"enter", "Document", nil},
+		[]any{"enter", "OperationDefinition", nil},
+		[]any{"enter", "SelectionSet", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "a"},
+		[]any{"leave", "Name", "a"},
+		[]any{"leave", "Field", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "b"},
+		[]any{"leave", "Name", "b"},
+		[]any{"enter", "SelectionSet", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "x"},
 	}
 
 	v := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"enter", node.Kind, node.Value})
+				visited = append(visited, []any{"enter", node.Kind, node.Value})
 				if node.Value == "x" {
 					return visitor.ActionBreak, nil
 				}
 			case ast.Node:
-				visited = append(visited, []interface{}{"enter", node.GetKind(), nil})
+				visited = append(visited, []any{"enter", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"enter", nil, nil})
+				visited = append(visited, []any{"enter", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
-		Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Leave: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"leave", node.Kind, node.Value})
+				visited = append(visited, []any{"leave", node.Kind, node.Value})
 			case ast.Node:
-				visited = append(visited, []interface{}{"leave", node.GetKind(), nil})
+				visited = append(visited, []any{"leave", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"leave", nil, nil})
+				visited = append(visited, []any{"leave", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
@@ -1062,85 +1062,85 @@ func TestVisitor_VisitInParallel_AllowsEarlyExitWhileVisiting(t *testing.T) {
 
 func TestVisitor_VisitInParallel_AllowsEarlyExitFromDifferentPoints(t *testing.T) {
 
-	visited := []interface{}{}
+	visited := []any{}
 
 	query := `{ a { y }, b { x } }`
 	astDoc := parse(t, query)
 
-	expectedVisited := []interface{}{
-		[]interface{}{"break-a", "enter", "Document", nil},
-		[]interface{}{"break-b", "enter", "Document", nil},
-		[]interface{}{"break-a", "enter", "OperationDefinition", nil},
-		[]interface{}{"break-b", "enter", "OperationDefinition", nil},
-		[]interface{}{"break-a", "enter", "SelectionSet", nil},
-		[]interface{}{"break-b", "enter", "SelectionSet", nil},
-		[]interface{}{"break-a", "enter", "Field", nil},
-		[]interface{}{"break-b", "enter", "Field", nil},
-		[]interface{}{"break-a", "enter", "Name", "a"},
-		[]interface{}{"break-b", "enter", "Name", "a"},
-		[]interface{}{"break-b", "leave", "Name", "a"},
-		[]interface{}{"break-b", "enter", "SelectionSet", nil},
-		[]interface{}{"break-b", "enter", "Field", nil},
-		[]interface{}{"break-b", "enter", "Name", "y"},
-		[]interface{}{"break-b", "leave", "Name", "y"},
-		[]interface{}{"break-b", "leave", "Field", nil},
-		[]interface{}{"break-b", "leave", "SelectionSet", nil},
-		[]interface{}{"break-b", "leave", "Field", nil},
-		[]interface{}{"break-b", "enter", "Field", nil},
-		[]interface{}{"break-b", "enter", "Name", "b"},
+	expectedVisited := []any{
+		[]any{"break-a", "enter", "Document", nil},
+		[]any{"break-b", "enter", "Document", nil},
+		[]any{"break-a", "enter", "OperationDefinition", nil},
+		[]any{"break-b", "enter", "OperationDefinition", nil},
+		[]any{"break-a", "enter", "SelectionSet", nil},
+		[]any{"break-b", "enter", "SelectionSet", nil},
+		[]any{"break-a", "enter", "Field", nil},
+		[]any{"break-b", "enter", "Field", nil},
+		[]any{"break-a", "enter", "Name", "a"},
+		[]any{"break-b", "enter", "Name", "a"},
+		[]any{"break-b", "leave", "Name", "a"},
+		[]any{"break-b", "enter", "SelectionSet", nil},
+		[]any{"break-b", "enter", "Field", nil},
+		[]any{"break-b", "enter", "Name", "y"},
+		[]any{"break-b", "leave", "Name", "y"},
+		[]any{"break-b", "leave", "Field", nil},
+		[]any{"break-b", "leave", "SelectionSet", nil},
+		[]any{"break-b", "leave", "Field", nil},
+		[]any{"break-b", "enter", "Field", nil},
+		[]any{"break-b", "enter", "Name", "b"},
 	}
 
 	v := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"break-a", "enter", node.Kind, node.Value})
+				visited = append(visited, []any{"break-a", "enter", node.Kind, node.Value})
 				if node != nil && node.Value == "a" {
 					return visitor.ActionBreak, nil
 				}
 			case ast.Node:
-				visited = append(visited, []interface{}{"break-a", "enter", node.GetKind(), nil})
+				visited = append(visited, []any{"break-a", "enter", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"break-a", "enter", nil, nil})
+				visited = append(visited, []any{"break-a", "enter", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
-		Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Leave: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"break-a", "leave", node.Kind, node.Value})
+				visited = append(visited, []any{"break-a", "leave", node.Kind, node.Value})
 			case ast.Node:
-				visited = append(visited, []interface{}{"break-a", "leave", node.GetKind(), nil})
+				visited = append(visited, []any{"break-a", "leave", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"break-a", "leave", nil, nil})
+				visited = append(visited, []any{"break-a", "leave", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
 	}
 
 	v2 := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"break-b", "enter", node.Kind, node.Value})
+				visited = append(visited, []any{"break-b", "enter", node.Kind, node.Value})
 				if node != nil && node.Value == "b" {
 					return visitor.ActionBreak, nil
 				}
 			case ast.Node:
-				visited = append(visited, []interface{}{"break-b", "enter", node.GetKind(), nil})
+				visited = append(visited, []any{"break-b", "enter", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"break-b", "enter", nil, nil})
+				visited = append(visited, []any{"break-b", "enter", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
-		Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Leave: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"break-b", "leave", node.Kind, node.Value})
+				visited = append(visited, []any{"break-b", "leave", node.Kind, node.Value})
 			case ast.Node:
-				visited = append(visited, []interface{}{"break-b", "leave", node.GetKind(), nil})
+				visited = append(visited, []any{"break-b", "leave", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"break-b", "leave", nil, nil})
+				visited = append(visited, []any{"break-b", "leave", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
@@ -1155,51 +1155,51 @@ func TestVisitor_VisitInParallel_AllowsEarlyExitFromDifferentPoints(t *testing.T
 
 func TestVisitor_VisitInParallel_AllowsEarlyExitWhileLeaving(t *testing.T) {
 
-	visited := []interface{}{}
+	visited := []any{}
 
 	query := `{ a, b { x }, c }`
 	astDoc := parse(t, query)
 
-	expectedVisited := []interface{}{
-		[]interface{}{"enter", "Document", nil},
-		[]interface{}{"enter", "OperationDefinition", nil},
-		[]interface{}{"enter", "SelectionSet", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "a"},
-		[]interface{}{"leave", "Name", "a"},
-		[]interface{}{"leave", "Field", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "b"},
-		[]interface{}{"leave", "Name", "b"},
-		[]interface{}{"enter", "SelectionSet", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "x"},
-		[]interface{}{"leave", "Name", "x"},
+	expectedVisited := []any{
+		[]any{"enter", "Document", nil},
+		[]any{"enter", "OperationDefinition", nil},
+		[]any{"enter", "SelectionSet", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "a"},
+		[]any{"leave", "Name", "a"},
+		[]any{"leave", "Field", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "b"},
+		[]any{"leave", "Name", "b"},
+		[]any{"enter", "SelectionSet", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "x"},
+		[]any{"leave", "Name", "x"},
 	}
 
 	v := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"enter", node.Kind, node.Value})
+				visited = append(visited, []any{"enter", node.Kind, node.Value})
 			case ast.Node:
-				visited = append(visited, []interface{}{"enter", node.GetKind(), nil})
+				visited = append(visited, []any{"enter", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"enter", nil, nil})
+				visited = append(visited, []any{"enter", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
-		Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Leave: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"leave", node.Kind, node.Value})
+				visited = append(visited, []any{"leave", node.Kind, node.Value})
 				if node.Value == "x" {
 					return visitor.ActionBreak, nil
 				}
 			case ast.Node:
-				visited = append(visited, []interface{}{"leave", node.GetKind(), nil})
+				visited = append(visited, []any{"leave", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"leave", nil, nil})
+				visited = append(visited, []any{"leave", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
@@ -1214,105 +1214,105 @@ func TestVisitor_VisitInParallel_AllowsEarlyExitWhileLeaving(t *testing.T) {
 
 func TestVisitor_VisitInParallel_AllowsEarlyExitFromLeavingDifferentPoints(t *testing.T) {
 
-	visited := []interface{}{}
+	visited := []any{}
 
 	query := `{ a { y }, b { x } }`
 	astDoc := parse(t, query)
 
-	expectedVisited := []interface{}{
-		[]interface{}{"break-a", "enter", "Document", nil},
-		[]interface{}{"break-b", "enter", "Document", nil},
-		[]interface{}{"break-a", "enter", "OperationDefinition", nil},
-		[]interface{}{"break-b", "enter", "OperationDefinition", nil},
-		[]interface{}{"break-a", "enter", "SelectionSet", nil},
-		[]interface{}{"break-b", "enter", "SelectionSet", nil},
-		[]interface{}{"break-a", "enter", "Field", nil},
-		[]interface{}{"break-b", "enter", "Field", nil},
-		[]interface{}{"break-a", "enter", "Name", "a"},
-		[]interface{}{"break-b", "enter", "Name", "a"},
-		[]interface{}{"break-a", "leave", "Name", "a"},
-		[]interface{}{"break-b", "leave", "Name", "a"},
-		[]interface{}{"break-a", "enter", "SelectionSet", nil},
-		[]interface{}{"break-b", "enter", "SelectionSet", nil},
-		[]interface{}{"break-a", "enter", "Field", nil},
-		[]interface{}{"break-b", "enter", "Field", nil},
-		[]interface{}{"break-a", "enter", "Name", "y"},
-		[]interface{}{"break-b", "enter", "Name", "y"},
-		[]interface{}{"break-a", "leave", "Name", "y"},
-		[]interface{}{"break-b", "leave", "Name", "y"},
-		[]interface{}{"break-a", "leave", "Field", nil},
-		[]interface{}{"break-b", "leave", "Field", nil},
-		[]interface{}{"break-a", "leave", "SelectionSet", nil},
-		[]interface{}{"break-b", "leave", "SelectionSet", nil},
-		[]interface{}{"break-a", "leave", "Field", nil},
-		[]interface{}{"break-b", "leave", "Field", nil},
-		[]interface{}{"break-b", "enter", "Field", nil},
-		[]interface{}{"break-b", "enter", "Name", "b"},
-		[]interface{}{"break-b", "leave", "Name", "b"},
-		[]interface{}{"break-b", "enter", "SelectionSet", nil},
-		[]interface{}{"break-b", "enter", "Field", nil},
-		[]interface{}{"break-b", "enter", "Name", "x"},
-		[]interface{}{"break-b", "leave", "Name", "x"},
-		[]interface{}{"break-b", "leave", "Field", nil},
-		[]interface{}{"break-b", "leave", "SelectionSet", nil},
-		[]interface{}{"break-b", "leave", "Field", nil},
+	expectedVisited := []any{
+		[]any{"break-a", "enter", "Document", nil},
+		[]any{"break-b", "enter", "Document", nil},
+		[]any{"break-a", "enter", "OperationDefinition", nil},
+		[]any{"break-b", "enter", "OperationDefinition", nil},
+		[]any{"break-a", "enter", "SelectionSet", nil},
+		[]any{"break-b", "enter", "SelectionSet", nil},
+		[]any{"break-a", "enter", "Field", nil},
+		[]any{"break-b", "enter", "Field", nil},
+		[]any{"break-a", "enter", "Name", "a"},
+		[]any{"break-b", "enter", "Name", "a"},
+		[]any{"break-a", "leave", "Name", "a"},
+		[]any{"break-b", "leave", "Name", "a"},
+		[]any{"break-a", "enter", "SelectionSet", nil},
+		[]any{"break-b", "enter", "SelectionSet", nil},
+		[]any{"break-a", "enter", "Field", nil},
+		[]any{"break-b", "enter", "Field", nil},
+		[]any{"break-a", "enter", "Name", "y"},
+		[]any{"break-b", "enter", "Name", "y"},
+		[]any{"break-a", "leave", "Name", "y"},
+		[]any{"break-b", "leave", "Name", "y"},
+		[]any{"break-a", "leave", "Field", nil},
+		[]any{"break-b", "leave", "Field", nil},
+		[]any{"break-a", "leave", "SelectionSet", nil},
+		[]any{"break-b", "leave", "SelectionSet", nil},
+		[]any{"break-a", "leave", "Field", nil},
+		[]any{"break-b", "leave", "Field", nil},
+		[]any{"break-b", "enter", "Field", nil},
+		[]any{"break-b", "enter", "Name", "b"},
+		[]any{"break-b", "leave", "Name", "b"},
+		[]any{"break-b", "enter", "SelectionSet", nil},
+		[]any{"break-b", "enter", "Field", nil},
+		[]any{"break-b", "enter", "Name", "x"},
+		[]any{"break-b", "leave", "Name", "x"},
+		[]any{"break-b", "leave", "Field", nil},
+		[]any{"break-b", "leave", "SelectionSet", nil},
+		[]any{"break-b", "leave", "Field", nil},
 	}
 
 	v := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"break-a", "enter", node.Kind, node.Value})
+				visited = append(visited, []any{"break-a", "enter", node.Kind, node.Value})
 			case ast.Node:
-				visited = append(visited, []interface{}{"break-a", "enter", node.GetKind(), nil})
+				visited = append(visited, []any{"break-a", "enter", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"break-a", "enter", nil, nil})
+				visited = append(visited, []any{"break-a", "enter", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
-		Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Leave: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Field:
-				visited = append(visited, []interface{}{"break-a", "leave", node.GetKind(), nil})
+				visited = append(visited, []any{"break-a", "leave", node.GetKind(), nil})
 				if node.Name != nil && node.Name.Value == "a" {
 					return visitor.ActionBreak, nil
 				}
 			case *ast.Name:
-				visited = append(visited, []interface{}{"break-a", "leave", node.Kind, node.Value})
+				visited = append(visited, []any{"break-a", "leave", node.Kind, node.Value})
 			case ast.Node:
-				visited = append(visited, []interface{}{"break-a", "leave", node.GetKind(), nil})
+				visited = append(visited, []any{"break-a", "leave", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"break-a", "leave", nil, nil})
+				visited = append(visited, []any{"break-a", "leave", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
 	}
 
 	v2 := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"break-b", "enter", node.Kind, node.Value})
+				visited = append(visited, []any{"break-b", "enter", node.Kind, node.Value})
 			case ast.Node:
-				visited = append(visited, []interface{}{"break-b", "enter", node.GetKind(), nil})
+				visited = append(visited, []any{"break-b", "enter", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"break-b", "enter", nil, nil})
+				visited = append(visited, []any{"break-b", "enter", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
-		Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Leave: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Field:
-				visited = append(visited, []interface{}{"break-b", "leave", node.GetKind(), nil})
+				visited = append(visited, []any{"break-b", "leave", node.GetKind(), nil})
 				if node.Name != nil && node.Name.Value == "b" {
 					return visitor.ActionBreak, nil
 				}
 			case *ast.Name:
-				visited = append(visited, []interface{}{"break-b", "leave", node.Kind, node.Value})
+				visited = append(visited, []any{"break-b", "leave", node.Kind, node.Value})
 			case ast.Node:
-				visited = append(visited, []interface{}{"break-b", "leave", node.GetKind(), nil})
+				visited = append(visited, []any{"break-b", "leave", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"break-b", "leave", nil, nil})
+				visited = append(visited, []any{"break-b", "leave", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
@@ -1327,40 +1327,40 @@ func TestVisitor_VisitInParallel_AllowsEarlyExitFromLeavingDifferentPoints(t *te
 
 func TestVisitor_VisitInParallel_AllowsForEditingOnEnter(t *testing.T) {
 
-	visited := []interface{}{}
+	visited := []any{}
 
 	query := `{ a, b, c { a, b, c } }`
 	astDoc := parse(t, query)
 
-	expectedVisited := []interface{}{
-		[]interface{}{"enter", "Document", nil},
-		[]interface{}{"enter", "OperationDefinition", nil},
-		[]interface{}{"enter", "SelectionSet", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "a"},
-		[]interface{}{"leave", "Name", "a"},
-		[]interface{}{"leave", "Field", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "c"},
-		[]interface{}{"leave", "Name", "c"},
-		[]interface{}{"enter", "SelectionSet", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "a"},
-		[]interface{}{"leave", "Name", "a"},
-		[]interface{}{"leave", "Field", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "c"},
-		[]interface{}{"leave", "Name", "c"},
-		[]interface{}{"leave", "Field", nil},
-		[]interface{}{"leave", "SelectionSet", nil},
-		[]interface{}{"leave", "Field", nil},
-		[]interface{}{"leave", "SelectionSet", nil},
-		[]interface{}{"leave", "OperationDefinition", nil},
-		[]interface{}{"leave", "Document", nil},
+	expectedVisited := []any{
+		[]any{"enter", "Document", nil},
+		[]any{"enter", "OperationDefinition", nil},
+		[]any{"enter", "SelectionSet", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "a"},
+		[]any{"leave", "Name", "a"},
+		[]any{"leave", "Field", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "c"},
+		[]any{"leave", "Name", "c"},
+		[]any{"enter", "SelectionSet", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "a"},
+		[]any{"leave", "Name", "a"},
+		[]any{"leave", "Field", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "c"},
+		[]any{"leave", "Name", "c"},
+		[]any{"leave", "Field", nil},
+		[]any{"leave", "SelectionSet", nil},
+		[]any{"leave", "Field", nil},
+		[]any{"leave", "SelectionSet", nil},
+		[]any{"leave", "OperationDefinition", nil},
+		[]any{"leave", "Document", nil},
 	}
 
 	v := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Field:
 				if node != nil && node.Name != nil && node.Name.Value == "b" {
@@ -1372,25 +1372,25 @@ func TestVisitor_VisitInParallel_AllowsForEditingOnEnter(t *testing.T) {
 	}
 
 	v2 := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"enter", node.Kind, node.Value})
+				visited = append(visited, []any{"enter", node.Kind, node.Value})
 			case ast.Node:
-				visited = append(visited, []interface{}{"enter", node.GetKind(), nil})
+				visited = append(visited, []any{"enter", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"enter", nil, nil})
+				visited = append(visited, []any{"enter", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
-		Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Leave: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"leave", node.Kind, node.Value})
+				visited = append(visited, []any{"leave", node.Kind, node.Value})
 			case ast.Node:
-				visited = append(visited, []interface{}{"leave", node.GetKind(), nil})
+				visited = append(visited, []any{"leave", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"leave", nil, nil})
+				visited = append(visited, []any{"leave", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
@@ -1405,46 +1405,46 @@ func TestVisitor_VisitInParallel_AllowsForEditingOnEnter(t *testing.T) {
 
 func TestVisitor_VisitInParallel_AllowsForEditingOnLeave(t *testing.T) {
 
-	visited := []interface{}{}
+	visited := []any{}
 
 	query := `{ a, b, c { a, b, c } }`
 	astDoc := parse(t, query)
 
-	expectedVisited := []interface{}{
-		[]interface{}{"enter", "Document", nil},
-		[]interface{}{"enter", "OperationDefinition", nil},
-		[]interface{}{"enter", "SelectionSet", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "a"},
-		[]interface{}{"leave", "Name", "a"},
-		[]interface{}{"leave", "Field", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "b"},
-		[]interface{}{"leave", "Name", "b"},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "c"},
-		[]interface{}{"leave", "Name", "c"},
-		[]interface{}{"enter", "SelectionSet", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "a"},
-		[]interface{}{"leave", "Name", "a"},
-		[]interface{}{"leave", "Field", nil},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "b"},
-		[]interface{}{"leave", "Name", "b"},
-		[]interface{}{"enter", "Field", nil},
-		[]interface{}{"enter", "Name", "c"},
-		[]interface{}{"leave", "Name", "c"},
-		[]interface{}{"leave", "Field", nil},
-		[]interface{}{"leave", "SelectionSet", nil},
-		[]interface{}{"leave", "Field", nil},
-		[]interface{}{"leave", "SelectionSet", nil},
-		[]interface{}{"leave", "OperationDefinition", nil},
-		[]interface{}{"leave", "Document", nil},
+	expectedVisited := []any{
+		[]any{"enter", "Document", nil},
+		[]any{"enter", "OperationDefinition", nil},
+		[]any{"enter", "SelectionSet", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "a"},
+		[]any{"leave", "Name", "a"},
+		[]any{"leave", "Field", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "b"},
+		[]any{"leave", "Name", "b"},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "c"},
+		[]any{"leave", "Name", "c"},
+		[]any{"enter", "SelectionSet", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "a"},
+		[]any{"leave", "Name", "a"},
+		[]any{"leave", "Field", nil},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "b"},
+		[]any{"leave", "Name", "b"},
+		[]any{"enter", "Field", nil},
+		[]any{"enter", "Name", "c"},
+		[]any{"leave", "Name", "c"},
+		[]any{"leave", "Field", nil},
+		[]any{"leave", "SelectionSet", nil},
+		[]any{"leave", "Field", nil},
+		[]any{"leave", "SelectionSet", nil},
+		[]any{"leave", "OperationDefinition", nil},
+		[]any{"leave", "Document", nil},
 	}
 
 	v := &visitor.VisitorOptions{
-		Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Leave: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Field:
 				if node != nil && node.Name != nil && node.Name.Value == "b" {
@@ -1456,25 +1456,25 @@ func TestVisitor_VisitInParallel_AllowsForEditingOnLeave(t *testing.T) {
 	}
 
 	v2 := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"enter", node.Kind, node.Value})
+				visited = append(visited, []any{"enter", node.Kind, node.Value})
 			case ast.Node:
-				visited = append(visited, []interface{}{"enter", node.GetKind(), nil})
+				visited = append(visited, []any{"enter", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"enter", nil, nil})
+				visited = append(visited, []any{"enter", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
-		Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Leave: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"leave", node.Kind, node.Value})
+				visited = append(visited, []any{"leave", node.Kind, node.Value})
 			case ast.Node:
-				visited = append(visited, []interface{}{"leave", node.GetKind(), nil})
+				visited = append(visited, []any{"leave", node.GetKind(), nil})
 			default:
-				visited = append(visited, []interface{}{"leave", nil, nil})
+				visited = append(visited, []any{"leave", nil, nil})
 			}
 			return visitor.ActionNoChange, nil
 		},
@@ -1494,7 +1494,7 @@ func TestVisitor_VisitInParallel_AllowsForEditingOnLeave(t *testing.T) {
 
 func TestVisitor_VisitWithTypeInfo_MaintainsTypeInfoDuringVisit(t *testing.T) {
 
-	visited := []interface{}{}
+	visited := []any{}
 
 	typeInfo := graphql.NewTypeInfo(&graphql.TypeInfoConfig{
 		Schema: testutil.TestSchema,
@@ -1503,50 +1503,50 @@ func TestVisitor_VisitWithTypeInfo_MaintainsTypeInfoDuringVisit(t *testing.T) {
 	query := `{ human(id: 4) { name, pets { name }, unknown } }`
 	astDoc := parse(t, query)
 
-	expectedVisited := []interface{}{
-		[]interface{}{"enter", "Document", nil, nil, nil, nil},
-		[]interface{}{"enter", "OperationDefinition", nil, nil, "QueryRoot", nil},
-		[]interface{}{"enter", "SelectionSet", nil, "QueryRoot", "QueryRoot", nil},
-		[]interface{}{"enter", "Field", nil, "QueryRoot", "Human", nil},
-		[]interface{}{"enter", "Name", "human", "QueryRoot", "Human", nil},
-		[]interface{}{"leave", "Name", "human", "QueryRoot", "Human", nil},
-		[]interface{}{"enter", "Argument", nil, "QueryRoot", "Human", "ID"},
-		[]interface{}{"enter", "Name", "id", "QueryRoot", "Human", "ID"},
-		[]interface{}{"leave", "Name", "id", "QueryRoot", "Human", "ID"},
-		[]interface{}{"enter", "IntValue", nil, "QueryRoot", "Human", "ID"},
-		[]interface{}{"leave", "IntValue", nil, "QueryRoot", "Human", "ID"},
-		[]interface{}{"leave", "Argument", nil, "QueryRoot", "Human", "ID"},
-		[]interface{}{"enter", "SelectionSet", nil, "Human", "Human", nil},
-		[]interface{}{"enter", "Field", nil, "Human", "String", nil},
-		[]interface{}{"enter", "Name", "name", "Human", "String", nil},
-		[]interface{}{"leave", "Name", "name", "Human", "String", nil},
-		[]interface{}{"leave", "Field", nil, "Human", "String", nil},
-		[]interface{}{"enter", "Field", nil, "Human", "[Pet]", nil},
-		[]interface{}{"enter", "Name", "pets", "Human", "[Pet]", nil},
-		[]interface{}{"leave", "Name", "pets", "Human", "[Pet]", nil},
-		[]interface{}{"enter", "SelectionSet", nil, "Pet", "[Pet]", nil},
-		[]interface{}{"enter", "Field", nil, "Pet", "String", nil},
-		[]interface{}{"enter", "Name", "name", "Pet", "String", nil},
-		[]interface{}{"leave", "Name", "name", "Pet", "String", nil},
-		[]interface{}{"leave", "Field", nil, "Pet", "String", nil},
-		[]interface{}{"leave", "SelectionSet", nil, "Pet", "[Pet]", nil},
-		[]interface{}{"leave", "Field", nil, "Human", "[Pet]", nil},
-		[]interface{}{"enter", "Field", nil, "Human", nil, nil},
-		[]interface{}{"enter", "Name", "unknown", "Human", nil, nil},
-		[]interface{}{"leave", "Name", "unknown", "Human", nil, nil},
-		[]interface{}{"leave", "Field", nil, "Human", nil, nil},
-		[]interface{}{"leave", "SelectionSet", nil, "Human", "Human", nil},
-		[]interface{}{"leave", "Field", nil, "QueryRoot", "Human", nil},
-		[]interface{}{"leave", "SelectionSet", nil, "QueryRoot", "QueryRoot", nil},
-		[]interface{}{"leave", "OperationDefinition", nil, nil, "QueryRoot", nil},
-		[]interface{}{"leave", "Document", nil, nil, nil, nil},
+	expectedVisited := []any{
+		[]any{"enter", "Document", nil, nil, nil, nil},
+		[]any{"enter", "OperationDefinition", nil, nil, "QueryRoot", nil},
+		[]any{"enter", "SelectionSet", nil, "QueryRoot", "QueryRoot", nil},
+		[]any{"enter", "Field", nil, "QueryRoot", "Human", nil},
+		[]any{"enter", "Name", "human", "QueryRoot", "Human", nil},
+		[]any{"leave", "Name", "human", "QueryRoot", "Human", nil},
+		[]any{"enter", "Argument", nil, "QueryRoot", "Human", "ID"},
+		[]any{"enter", "Name", "id", "QueryRoot", "Human", "ID"},
+		[]any{"leave", "Name", "id", "QueryRoot", "Human", "ID"},
+		[]any{"enter", "IntValue", nil, "QueryRoot", "Human", "ID"},
+		[]any{"leave", "IntValue", nil, "QueryRoot", "Human", "ID"},
+		[]any{"leave", "Argument", nil, "QueryRoot", "Human", "ID"},
+		[]any{"enter", "SelectionSet", nil, "Human", "Human", nil},
+		[]any{"enter", "Field", nil, "Human", "String", nil},
+		[]any{"enter", "Name", "name", "Human", "String", nil},
+		[]any{"leave", "Name", "name", "Human", "String", nil},
+		[]any{"leave", "Field", nil, "Human", "String", nil},
+		[]any{"enter", "Field", nil, "Human", "[Pet]", nil},
+		[]any{"enter", "Name", "pets", "Human", "[Pet]", nil},
+		[]any{"leave", "Name", "pets", "Human", "[Pet]", nil},
+		[]any{"enter", "SelectionSet", nil, "Pet", "[Pet]", nil},
+		[]any{"enter", "Field", nil, "Pet", "String", nil},
+		[]any{"enter", "Name", "name", "Pet", "String", nil},
+		[]any{"leave", "Name", "name", "Pet", "String", nil},
+		[]any{"leave", "Field", nil, "Pet", "String", nil},
+		[]any{"leave", "SelectionSet", nil, "Pet", "[Pet]", nil},
+		[]any{"leave", "Field", nil, "Human", "[Pet]", nil},
+		[]any{"enter", "Field", nil, "Human", nil, nil},
+		[]any{"enter", "Name", "unknown", "Human", nil, nil},
+		[]any{"leave", "Name", "unknown", "Human", nil, nil},
+		[]any{"leave", "Field", nil, "Human", nil, nil},
+		[]any{"leave", "SelectionSet", nil, "Human", "Human", nil},
+		[]any{"leave", "Field", nil, "QueryRoot", "Human", nil},
+		[]any{"leave", "SelectionSet", nil, "QueryRoot", "QueryRoot", nil},
+		[]any{"leave", "OperationDefinition", nil, nil, "QueryRoot", nil},
+		[]any{"leave", "Document", nil, nil, nil, nil},
 	}
 
 	v := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
-			var parentType interface{}
-			var ttype interface{}
-			var inputType interface{}
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
+			var parentType any
+			var ttype any
+			var inputType any
 
 			if typeInfo.ParentType() != nil {
 				parentType = fmt.Sprintf("%v", typeInfo.ParentType())
@@ -1560,18 +1560,18 @@ func TestVisitor_VisitWithTypeInfo_MaintainsTypeInfoDuringVisit(t *testing.T) {
 
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"enter", node.Kind, node.Value, parentType, ttype, inputType})
+				visited = append(visited, []any{"enter", node.Kind, node.Value, parentType, ttype, inputType})
 			case ast.Node:
-				visited = append(visited, []interface{}{"enter", node.GetKind(), nil, parentType, ttype, inputType})
+				visited = append(visited, []any{"enter", node.GetKind(), nil, parentType, ttype, inputType})
 			default:
-				visited = append(visited, []interface{}{"enter", nil, nil, parentType, ttype, inputType})
+				visited = append(visited, []any{"enter", nil, nil, parentType, ttype, inputType})
 			}
 			return visitor.ActionNoChange, nil
 		},
-		Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
-			var parentType interface{}
-			var ttype interface{}
-			var inputType interface{}
+		Leave: func(p visitor.VisitFuncParams) (string, any) {
+			var parentType any
+			var ttype any
+			var inputType any
 
 			if typeInfo.ParentType() != nil {
 				parentType = fmt.Sprintf("%v", typeInfo.ParentType())
@@ -1585,11 +1585,11 @@ func TestVisitor_VisitWithTypeInfo_MaintainsTypeInfoDuringVisit(t *testing.T) {
 
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"leave", node.Kind, node.Value, parentType, ttype, inputType})
+				visited = append(visited, []any{"leave", node.Kind, node.Value, parentType, ttype, inputType})
 			case ast.Node:
-				visited = append(visited, []interface{}{"leave", node.GetKind(), nil, parentType, ttype, inputType})
+				visited = append(visited, []any{"leave", node.GetKind(), nil, parentType, ttype, inputType})
 			default:
-				visited = append(visited, []interface{}{"leave", nil, nil, parentType, ttype, inputType})
+				visited = append(visited, []any{"leave", nil, nil, parentType, ttype, inputType})
 			}
 			return visitor.ActionNoChange, nil
 		},
@@ -1605,7 +1605,7 @@ func TestVisitor_VisitWithTypeInfo_MaintainsTypeInfoDuringVisit(t *testing.T) {
 
 func TestVisitor_VisitWithTypeInfo_MaintainsTypeInfoDuringEdit(t *testing.T) {
 
-	visited := []interface{}{}
+	visited := []any{}
 
 	typeInfo := graphql.NewTypeInfo(&graphql.TypeInfoConfig{
 		Schema: testutil.TestSchema,
@@ -1613,56 +1613,56 @@ func TestVisitor_VisitWithTypeInfo_MaintainsTypeInfoDuringEdit(t *testing.T) {
 
 	astDoc := parse(t, `{ human(id: 4) { name, pets }, alien }`)
 
-	expectedVisited := []interface{}{
-		[]interface{}{"enter", "Document", nil, nil, nil, nil},
-		[]interface{}{"enter", "OperationDefinition", nil, nil, "QueryRoot", nil},
-		[]interface{}{"enter", "SelectionSet", nil, "QueryRoot", "QueryRoot", nil},
-		[]interface{}{"enter", "Field", nil, "QueryRoot", "Human", nil},
-		[]interface{}{"enter", "Name", "human", "QueryRoot", "Human", nil},
-		[]interface{}{"leave", "Name", "human", "QueryRoot", "Human", nil},
-		[]interface{}{"enter", "Argument", nil, "QueryRoot", "Human", "ID"},
-		[]interface{}{"enter", "Name", "id", "QueryRoot", "Human", "ID"},
-		[]interface{}{"leave", "Name", "id", "QueryRoot", "Human", "ID"},
-		[]interface{}{"enter", "IntValue", nil, "QueryRoot", "Human", "ID"},
-		[]interface{}{"leave", "IntValue", nil, "QueryRoot", "Human", "ID"},
-		[]interface{}{"leave", "Argument", nil, "QueryRoot", "Human", "ID"},
-		[]interface{}{"enter", "SelectionSet", nil, "Human", "Human", nil},
-		[]interface{}{"enter", "Field", nil, "Human", "String", nil},
-		[]interface{}{"enter", "Name", "name", "Human", "String", nil},
-		[]interface{}{"leave", "Name", "name", "Human", "String", nil},
-		[]interface{}{"leave", "Field", nil, "Human", "String", nil},
-		[]interface{}{"enter", "Field", nil, "Human", "[Pet]", nil},
-		[]interface{}{"enter", "Name", "pets", "Human", "[Pet]", nil},
-		[]interface{}{"leave", "Name", "pets", "Human", "[Pet]", nil},
-		[]interface{}{"enter", "SelectionSet", nil, "Pet", "[Pet]", nil},
-		[]interface{}{"enter", "Field", nil, "Pet", "String!", nil},
-		[]interface{}{"enter", "Name", "__typename", "Pet", "String!", nil},
-		[]interface{}{"leave", "Name", "__typename", "Pet", "String!", nil},
-		[]interface{}{"leave", "Field", nil, "Pet", "String!", nil},
-		[]interface{}{"leave", "SelectionSet", nil, "Pet", "[Pet]", nil},
-		[]interface{}{"leave", "Field", nil, "Human", "[Pet]", nil},
-		[]interface{}{"leave", "SelectionSet", nil, "Human", "Human", nil},
-		[]interface{}{"leave", "Field", nil, "QueryRoot", "Human", nil},
-		[]interface{}{"enter", "Field", nil, "QueryRoot", "Alien", nil},
-		[]interface{}{"enter", "Name", "alien", "QueryRoot", "Alien", nil},
-		[]interface{}{"leave", "Name", "alien", "QueryRoot", "Alien", nil},
-		[]interface{}{"enter", "SelectionSet", nil, "Alien", "Alien", nil},
-		[]interface{}{"enter", "Field", nil, "Alien", "String!", nil},
-		[]interface{}{"enter", "Name", "__typename", "Alien", "String!", nil},
-		[]interface{}{"leave", "Name", "__typename", "Alien", "String!", nil},
-		[]interface{}{"leave", "Field", nil, "Alien", "String!", nil},
-		[]interface{}{"leave", "SelectionSet", nil, "Alien", "Alien", nil},
-		[]interface{}{"leave", "Field", nil, "QueryRoot", "Alien", nil},
-		[]interface{}{"leave", "SelectionSet", nil, "QueryRoot", "QueryRoot", nil},
-		[]interface{}{"leave", "OperationDefinition", nil, nil, "QueryRoot", nil},
-		[]interface{}{"leave", "Document", nil, nil, nil, nil},
+	expectedVisited := []any{
+		[]any{"enter", "Document", nil, nil, nil, nil},
+		[]any{"enter", "OperationDefinition", nil, nil, "QueryRoot", nil},
+		[]any{"enter", "SelectionSet", nil, "QueryRoot", "QueryRoot", nil},
+		[]any{"enter", "Field", nil, "QueryRoot", "Human", nil},
+		[]any{"enter", "Name", "human", "QueryRoot", "Human", nil},
+		[]any{"leave", "Name", "human", "QueryRoot", "Human", nil},
+		[]any{"enter", "Argument", nil, "QueryRoot", "Human", "ID"},
+		[]any{"enter", "Name", "id", "QueryRoot", "Human", "ID"},
+		[]any{"leave", "Name", "id", "QueryRoot", "Human", "ID"},
+		[]any{"enter", "IntValue", nil, "QueryRoot", "Human", "ID"},
+		[]any{"leave", "IntValue", nil, "QueryRoot", "Human", "ID"},
+		[]any{"leave", "Argument", nil, "QueryRoot", "Human", "ID"},
+		[]any{"enter", "SelectionSet", nil, "Human", "Human", nil},
+		[]any{"enter", "Field", nil, "Human", "String", nil},
+		[]any{"enter", "Name", "name", "Human", "String", nil},
+		[]any{"leave", "Name", "name", "Human", "String", nil},
+		[]any{"leave", "Field", nil, "Human", "String", nil},
+		[]any{"enter", "Field", nil, "Human", "[Pet]", nil},
+		[]any{"enter", "Name", "pets", "Human", "[Pet]", nil},
+		[]any{"leave", "Name", "pets", "Human", "[Pet]", nil},
+		[]any{"enter", "SelectionSet", nil, "Pet", "[Pet]", nil},
+		[]any{"enter", "Field", nil, "Pet", "String!", nil},
+		[]any{"enter", "Name", "__typename", "Pet", "String!", nil},
+		[]any{"leave", "Name", "__typename", "Pet", "String!", nil},
+		[]any{"leave", "Field", nil, "Pet", "String!", nil},
+		[]any{"leave", "SelectionSet", nil, "Pet", "[Pet]", nil},
+		[]any{"leave", "Field", nil, "Human", "[Pet]", nil},
+		[]any{"leave", "SelectionSet", nil, "Human", "Human", nil},
+		[]any{"leave", "Field", nil, "QueryRoot", "Human", nil},
+		[]any{"enter", "Field", nil, "QueryRoot", "Alien", nil},
+		[]any{"enter", "Name", "alien", "QueryRoot", "Alien", nil},
+		[]any{"leave", "Name", "alien", "QueryRoot", "Alien", nil},
+		[]any{"enter", "SelectionSet", nil, "Alien", "Alien", nil},
+		[]any{"enter", "Field", nil, "Alien", "String!", nil},
+		[]any{"enter", "Name", "__typename", "Alien", "String!", nil},
+		[]any{"leave", "Name", "__typename", "Alien", "String!", nil},
+		[]any{"leave", "Field", nil, "Alien", "String!", nil},
+		[]any{"leave", "SelectionSet", nil, "Alien", "Alien", nil},
+		[]any{"leave", "Field", nil, "QueryRoot", "Alien", nil},
+		[]any{"leave", "SelectionSet", nil, "QueryRoot", "QueryRoot", nil},
+		[]any{"leave", "OperationDefinition", nil, nil, "QueryRoot", nil},
+		[]any{"leave", "Document", nil, nil, nil, nil},
 	}
 
 	v := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
-			var parentType interface{}
-			var ttype interface{}
-			var inputType interface{}
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
+			var parentType any
+			var ttype any
+			var inputType any
 
 			if typeInfo.ParentType() != nil {
 				parentType = fmt.Sprintf("%v", typeInfo.ParentType())
@@ -1676,9 +1676,9 @@ func TestVisitor_VisitWithTypeInfo_MaintainsTypeInfoDuringEdit(t *testing.T) {
 
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"enter", node.Kind, node.Value, parentType, ttype, inputType})
+				visited = append(visited, []any{"enter", node.Kind, node.Value, parentType, ttype, inputType})
 			case *ast.Field:
-				visited = append(visited, []interface{}{"enter", node.GetKind(), nil, parentType, ttype, inputType})
+				visited = append(visited, []any{"enter", node.GetKind(), nil, parentType, ttype, inputType})
 
 				// Make a query valid by adding missing selection sets.
 				if node.SelectionSet == nil && graphql.IsCompositeType(graphql.GetNamed(typeInfo.Type())) {
@@ -1699,17 +1699,17 @@ func TestVisitor_VisitWithTypeInfo_MaintainsTypeInfoDuringEdit(t *testing.T) {
 					})
 				}
 			case ast.Node:
-				visited = append(visited, []interface{}{"enter", node.GetKind(), nil, parentType, ttype, inputType})
+				visited = append(visited, []any{"enter", node.GetKind(), nil, parentType, ttype, inputType})
 			default:
-				visited = append(visited, []interface{}{"enter", nil, nil, parentType, ttype, inputType})
+				visited = append(visited, []any{"enter", nil, nil, parentType, ttype, inputType})
 			}
 
 			return visitor.ActionNoChange, nil
 		},
-		Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
-			var parentType interface{}
-			var ttype interface{}
-			var inputType interface{}
+		Leave: func(p visitor.VisitFuncParams) (string, any) {
+			var parentType any
+			var ttype any
+			var inputType any
 
 			if typeInfo.ParentType() != nil {
 				parentType = fmt.Sprintf("%v", typeInfo.ParentType())
@@ -1723,11 +1723,11 @@ func TestVisitor_VisitWithTypeInfo_MaintainsTypeInfoDuringEdit(t *testing.T) {
 
 			switch node := p.Node.(type) {
 			case *ast.Name:
-				visited = append(visited, []interface{}{"leave", node.Kind, node.Value, parentType, ttype, inputType})
+				visited = append(visited, []any{"leave", node.Kind, node.Value, parentType, ttype, inputType})
 			case ast.Node:
-				visited = append(visited, []interface{}{"leave", node.GetKind(), nil, parentType, ttype, inputType})
+				visited = append(visited, []any{"leave", node.GetKind(), nil, parentType, ttype, inputType})
 			default:
-				visited = append(visited, []interface{}{"leave", nil, nil, parentType, ttype, inputType})
+				visited = append(visited, []any{"leave", nil, nil, parentType, ttype, inputType})
 			}
 			return visitor.ActionNoChange, nil
 		},

--- a/lists_test.go
+++ b/lists_test.go
@@ -905,7 +905,7 @@ func TestLists_ValueMayBeNilPointer(t *testing.T) {
 		Schema:        listTestSchema,
 		RequestString: query,
 	})
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }

--- a/lists_test.go
+++ b/lists_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/machship/graphql/testutil"
 )
 
-func checkList(t *testing.T, testType graphql.Type, testData interface{}, expected *graphql.Result) {
+func checkList(t *testing.T, testType graphql.Type, testData any, expected *graphql.Result) {
 	// TODO: uncomment t.Helper when support for go1.8 is dropped.
 	//t.Helper()
-	data := map[string]interface{}{
+	data := map[string]any{
 		"test": testData,
 	}
 
@@ -27,7 +27,7 @@ func checkList(t *testing.T, testType graphql.Type, testData interface{}, expect
 	})
 	dataType.AddFieldConfig("nest", &graphql.Field{
 		Type: dataType,
-		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+		Resolve: func(p graphql.ResolveParams) (any, error) {
 			return data, nil
 		},
 	})
@@ -58,13 +58,13 @@ func checkList(t *testing.T, testType graphql.Type, testData interface{}, expect
 // Describe [T] Array<T>
 func TestLists_ListOfNullableObjects_ContainsValues(t *testing.T) {
 	ttype := graphql.NewList(graphql.Int)
-	data := []interface{}{
+	data := []any{
 		1, 2,
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
+				"test": []any{
 					1, 2,
 				},
 			},
@@ -74,13 +74,13 @@ func TestLists_ListOfNullableObjects_ContainsValues(t *testing.T) {
 }
 func TestLists_ListOfNullableObjects_ContainsNull(t *testing.T) {
 	ttype := graphql.NewList(graphql.Int)
-	data := []interface{}{
+	data := []any{
 		1, nil, 2,
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
+				"test": []any{
 					1, nil, 2,
 				},
 			},
@@ -91,8 +91,8 @@ func TestLists_ListOfNullableObjects_ContainsNull(t *testing.T) {
 func TestLists_ListOfNullableObjects_ReturnsNull(t *testing.T) {
 	ttype := graphql.NewList(graphql.Int)
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
 				"test": nil,
 			},
 		},
@@ -105,16 +105,16 @@ func TestLists_ListOfNullableFunc_ContainsValues(t *testing.T) {
 	ttype := graphql.NewList(graphql.Int)
 
 	// `data` is a function that return values
-	// Note that its uses the expected signature `func() interface{} {...}`
-	data := func() interface{} {
-		return []interface{}{
+	// Note that its uses the expected signature `func() any {...}`
+	data := func() any {
+		return []any{
 			1, 2,
 		}
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
+				"test": []any{
 					1, 2,
 				},
 			},
@@ -126,16 +126,16 @@ func TestLists_ListOfNullableFunc_ContainsNull(t *testing.T) {
 	ttype := graphql.NewList(graphql.Int)
 
 	// `data` is a function that return values
-	// Note that its uses the expected signature `func() interface{} {...}`
-	data := func() interface{} {
-		return []interface{}{
+	// Note that its uses the expected signature `func() any {...}`
+	data := func() any {
+		return []any{
 			1, nil, 2,
 		}
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
+				"test": []any{
 					1, nil, 2,
 				},
 			},
@@ -147,13 +147,13 @@ func TestLists_ListOfNullableFunc_ReturnsNull(t *testing.T) {
 	ttype := graphql.NewList(graphql.Int)
 
 	// `data` is a function that return values
-	// Note that its uses the expected signature `func() interface{} {...}`
-	data := func() interface{} {
+	// Note that its uses the expected signature `func() any {...}`
+	data := func() any {
 		return nil
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
 				"test": nil,
 			},
 		},
@@ -166,19 +166,19 @@ func TestLists_ListOfNullableArrayOfFuncContainsValues(t *testing.T) {
 	ttype := graphql.NewList(graphql.Int)
 
 	// `data` is a slice of functions that return values
-	// Note that its uses the expected signature `func() (interface{}, error) {...}`
-	data := []interface{}{
-		func() (interface{}, error) {
+	// Note that its uses the expected signature `func() (any, error) {...}`
+	data := []any{
+		func() (any, error) {
 			return 1, nil
 		},
-		func() (interface{}, error) {
+		func() (any, error) {
 			return 2, nil
 		},
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
+				"test": []any{
 					1, 2,
 				},
 			},
@@ -190,22 +190,22 @@ func TestLists_ListOfNullableArrayOfFuncContainsNulls(t *testing.T) {
 	ttype := graphql.NewList(graphql.Int)
 
 	// `data` is a slice of functions that return values
-	// Note that its uses the expected signature `func() (interface{}, error) {...}`
-	data := []interface{}{
-		func() (interface{}, error) {
+	// Note that its uses the expected signature `func() (any, error) {...}`
+	data := []any{
+		func() (any, error) {
 			return 1, nil
 		},
-		func() (interface{}, error) {
+		func() (any, error) {
 			return nil, nil
 		},
-		func() (interface{}, error) {
+		func() (any, error) {
 			return 2, nil
 		},
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
+				"test": []any{
 					1, nil, 2,
 				},
 			},
@@ -217,13 +217,13 @@ func TestLists_ListOfNullableArrayOfFuncContainsNulls(t *testing.T) {
 // Describe [T]! Array<T>
 func TestLists_NonNullListOfNullableObjectsContainsValues(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.Int))
-	data := []interface{}{
+	data := []any{
 		1, 2,
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
+				"test": []any{
 					1, 2,
 				},
 			},
@@ -233,13 +233,13 @@ func TestLists_NonNullListOfNullableObjectsContainsValues(t *testing.T) {
 }
 func TestLists_NonNullListOfNullableObjectsContainsNull(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.Int))
-	data := []interface{}{
+	data := []any{
 		1, nil, 2,
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
+				"test": []any{
 					1, nil, 2,
 				},
 			},
@@ -250,7 +250,7 @@ func TestLists_NonNullListOfNullableObjectsContainsNull(t *testing.T) {
 func TestLists_NonNullListOfNullableObjectsReturnsNull(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.Int))
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"nest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -262,7 +262,7 @@ func TestLists_NonNullListOfNullableObjectsReturnsNull(t *testing.T) {
 						Column: 10,
 					},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest",
 					"test",
 				},
@@ -277,16 +277,16 @@ func TestLists_NonNullListOfNullableFunc_ContainsValues(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.Int))
 
 	// `data` is a function that return values
-	// Note that its uses the expected signature `func() interface{} {...}`
-	data := func() interface{} {
-		return []interface{}{
+	// Note that its uses the expected signature `func() any {...}`
+	data := func() any {
+		return []any{
 			1, 2,
 		}
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
+				"test": []any{
 					1, 2,
 				},
 			},
@@ -298,16 +298,16 @@ func TestLists_NonNullListOfNullableFunc_ContainsNull(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.Int))
 
 	// `data` is a function that return values
-	// Note that its uses the expected signature `func() interface{} {...}`
-	data := func() interface{} {
-		return []interface{}{
+	// Note that its uses the expected signature `func() any {...}`
+	data := func() any {
+		return []any{
 			1, nil, 2,
 		}
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
+				"test": []any{
 					1, nil, 2,
 				},
 			},
@@ -319,12 +319,12 @@ func TestLists_NonNullListOfNullableFunc_ReturnsNull(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.Int))
 
 	// `data` is a function that return values
-	// Note that its uses the expected signature `func() interface{} {...}`
-	data := func() interface{} {
+	// Note that its uses the expected signature `func() any {...}`
+	data := func() any {
 		return nil
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"nest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -336,7 +336,7 @@ func TestLists_NonNullListOfNullableFunc_ReturnsNull(t *testing.T) {
 						Column: 10,
 					},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest",
 					"test",
 				},
@@ -351,19 +351,19 @@ func TestLists_NonNullListOfNullableArrayOfFunc_ContainsValues(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.Int))
 
 	// `data` is a slice of functions that return values
-	// Note that its uses the expected signature `func() (interface{}, error) {...}`
-	data := []interface{}{
-		func() (interface{}, error) {
+	// Note that its uses the expected signature `func() (any, error) {...}`
+	data := []any{
+		func() (any, error) {
 			return 1, nil
 		},
-		func() (interface{}, error) {
+		func() (any, error) {
 			return 2, nil
 		},
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
+				"test": []any{
 					1, 2,
 				},
 			},
@@ -375,22 +375,22 @@ func TestLists_NonNullListOfNullableArrayOfFunc_ContainsNulls(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.Int))
 
 	// `data` is a slice of functions that return values
-	// Note that its uses the expected signature `func() (interface{}, error) {...}`
-	data := []interface{}{
-		func() (interface{}, error) {
+	// Note that its uses the expected signature `func() (any, error) {...}`
+	data := []any{
+		func() (any, error) {
 			return 1, nil
 		},
-		func() (interface{}, error) {
+		func() (any, error) {
 			return nil, nil
 		},
-		func() (interface{}, error) {
+		func() (any, error) {
 			return 2, nil
 		},
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
+				"test": []any{
 					1, nil, 2,
 				},
 			},
@@ -402,13 +402,13 @@ func TestLists_NonNullListOfNullableArrayOfFunc_ContainsNulls(t *testing.T) {
 // Describe [T!] Array<T>
 func TestLists_NullableListOfNonNullObjects_ContainsValues(t *testing.T) {
 	ttype := graphql.NewList(graphql.NewNonNull(graphql.Int))
-	data := []interface{}{
+	data := []any{
 		1, 2,
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
+				"test": []any{
 					1, 2,
 				},
 			},
@@ -418,12 +418,12 @@ func TestLists_NullableListOfNonNullObjects_ContainsValues(t *testing.T) {
 }
 func TestLists_NullableListOfNonNullObjects_ContainsNull(t *testing.T) {
 	ttype := graphql.NewList(graphql.NewNonNull(graphql.Int))
-	data := []interface{}{
+	data := []any{
 		1, nil, 2,
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
 				"test": nil,
 			},
 		},
@@ -436,7 +436,7 @@ func TestLists_NullableListOfNonNullObjects_ContainsNull(t *testing.T) {
 						Column: 10,
 					},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest",
 					"test",
 					1,
@@ -450,8 +450,8 @@ func TestLists_NullableListOfNonNullObjects_ReturnsNull(t *testing.T) {
 	ttype := graphql.NewList(graphql.NewNonNull(graphql.Int))
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
 				"test": nil,
 			},
 		},
@@ -464,16 +464,16 @@ func TestLists_NullableListOfNonNullFunc_ContainsValues(t *testing.T) {
 	ttype := graphql.NewList(graphql.NewNonNull(graphql.Int))
 
 	// `data` is a function that return values
-	// Note that its uses the expected signature `func() interface{} {...}`
-	data := func() interface{} {
-		return []interface{}{
+	// Note that its uses the expected signature `func() any {...}`
+	data := func() any {
+		return []any{
 			1, 2,
 		}
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
+				"test": []any{
 					1, 2,
 				},
 			},
@@ -485,15 +485,15 @@ func TestLists_NullableListOfNonNullFunc_ContainsNull(t *testing.T) {
 	ttype := graphql.NewList(graphql.NewNonNull(graphql.Int))
 
 	// `data` is a function that return values
-	// Note that its uses the expected signature `func() interface{} {...}`
-	data := func() interface{} {
-		return []interface{}{
+	// Note that its uses the expected signature `func() any {...}`
+	data := func() any {
+		return []any{
 			1, nil, 2,
 		}
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
 				"test": nil,
 			},
 		},
@@ -506,7 +506,7 @@ func TestLists_NullableListOfNonNullFunc_ContainsNull(t *testing.T) {
 						Column: 10,
 					},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest",
 					"test",
 					1,
@@ -520,13 +520,13 @@ func TestLists_NullableListOfNonNullFunc_ReturnsNull(t *testing.T) {
 	ttype := graphql.NewList(graphql.NewNonNull(graphql.Int))
 
 	// `data` is a function that return values
-	// Note that its uses the expected signature `func() interface{} {...}`
-	data := func() interface{} {
+	// Note that its uses the expected signature `func() any {...}`
+	data := func() any {
 		return nil
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
 				"test": nil,
 			},
 		},
@@ -539,19 +539,19 @@ func TestLists_NullableListOfNonNullArrayOfFunc_ContainsValues(t *testing.T) {
 	ttype := graphql.NewList(graphql.NewNonNull(graphql.Int))
 
 	// `data` is a slice of functions that return values
-	// Note that its uses the expected signature `func() interface{} {...}`
-	data := []interface{}{
-		func() (interface{}, error) {
+	// Note that its uses the expected signature `func() any {...}`
+	data := []any{
+		func() (any, error) {
 			return 1, nil
 		},
-		func() (interface{}, error) {
+		func() (any, error) {
 			return 2, nil
 		},
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
+				"test": []any{
 					1, 2,
 				},
 			},
@@ -563,15 +563,15 @@ func TestLists_NullableListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
 	ttype := graphql.NewList(graphql.NewNonNull(graphql.Int))
 
 	// `data` is a slice of functions that return values
-	// Note that its uses the expected signature `func() (interface{}, error){...}`
-	data := []interface{}{
-		func() (interface{}, error) {
+	// Note that its uses the expected signature `func() (any, error){...}`
+	data := []any{
+		func() (any, error) {
 			return 1, nil
 		},
-		func() (interface{}, error) {
+		func() (any, error) {
 			return nil, nil
 		},
-		func() (interface{}, error) {
+		func() (any, error) {
 			return 2, nil
 		},
 	}
@@ -581,8 +581,8 @@ func TestLists_NullableListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
 			// we are not able to traverse up the tree until we find a nullable type,
 			// so in this case the entire data is nil. Will need some significant code
 			// restructure to restore this.
-			Data: map[string]interface{}{
-				"nest": map[string]interface{}{
+			Data: map[string]any{
+				"nest": map[string]any{
 					"test": nil,
 				},
 			},
@@ -597,7 +597,7 @@ func TestLists_NullableListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
 						Column: 10,
 					},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest",
 					"test",
 					1,
@@ -611,13 +611,13 @@ func TestLists_NullableListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
 // Describe [T!]! Array<T>
 func TestLists_NonNullListOfNonNullObjects_ContainsValues(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(graphql.Int)))
-	data := []interface{}{
+	data := []any{
 		1, 2,
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
+				"test": []any{
 					1, 2,
 				},
 			},
@@ -627,11 +627,11 @@ func TestLists_NonNullListOfNonNullObjects_ContainsValues(t *testing.T) {
 }
 func TestLists_NonNullListOfNonNullObjects_ContainsNull(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(graphql.Int)))
-	data := []interface{}{
+	data := []any{
 		1, nil, 2,
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"nest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -643,7 +643,7 @@ func TestLists_NonNullListOfNonNullObjects_ContainsNull(t *testing.T) {
 						Column: 10,
 					},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest",
 					"test",
 					1,
@@ -656,7 +656,7 @@ func TestLists_NonNullListOfNonNullObjects_ContainsNull(t *testing.T) {
 func TestLists_NonNullListOfNonNullObjects_ReturnsNull(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(graphql.Int)))
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"nest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -668,7 +668,7 @@ func TestLists_NonNullListOfNonNullObjects_ReturnsNull(t *testing.T) {
 						Column: 10,
 					},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest",
 					"test",
 				},
@@ -683,16 +683,16 @@ func TestLists_NonNullListOfNonNullFunc_ContainsValues(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(graphql.Int)))
 
 	// `data` is a function that return values
-	// Note that its uses the expected signature `func() interface{} {...}`
-	data := func() interface{} {
-		return []interface{}{
+	// Note that its uses the expected signature `func() any {...}`
+	data := func() any {
+		return []any{
 			1, 2,
 		}
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
+				"test": []any{
 					1, 2,
 				},
 			},
@@ -704,14 +704,14 @@ func TestLists_NonNullListOfNonNullFunc_ContainsNull(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(graphql.Int)))
 
 	// `data` is a function that return values
-	// Note that its uses the expected signature `func() interface{} {...}`
-	data := func() interface{} {
-		return []interface{}{
+	// Note that its uses the expected signature `func() any {...}`
+	data := func() any {
+		return []any{
 			1, nil, 2,
 		}
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"nest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -723,7 +723,7 @@ func TestLists_NonNullListOfNonNullFunc_ContainsNull(t *testing.T) {
 						Column: 10,
 					},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest",
 					"test",
 					1,
@@ -737,12 +737,12 @@ func TestLists_NonNullListOfNonNullFunc_ReturnsNull(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(graphql.Int)))
 
 	// `data` is a function that return values
-	// Note that its uses the expected signature `func() interface{} {...}`
-	data := func() interface{} {
+	// Note that its uses the expected signature `func() any {...}`
+	data := func() any {
 		return nil
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"nest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -754,7 +754,7 @@ func TestLists_NonNullListOfNonNullFunc_ReturnsNull(t *testing.T) {
 						Column: 10,
 					},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest",
 					"test",
 				},
@@ -769,19 +769,19 @@ func TestLists_NonNullListOfNonNullArrayOfFunc_ContainsValues(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(graphql.Int)))
 
 	// `data` is a slice of functions that return values
-	// Note that its uses the expected signature `func() (interface{}, error) {...}`
-	data := []interface{}{
-		func() (interface{}, error) {
+	// Note that its uses the expected signature `func() (any, error) {...}`
+	data := []any{
+		func() (any, error) {
 			return 1, nil
 		},
-		func() (interface{}, error) {
+		func() (any, error) {
 			return 2, nil
 		},
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
+				"test": []any{
 					1, 2,
 				},
 			},
@@ -793,15 +793,15 @@ func TestLists_NonNullListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(graphql.Int)))
 
 	// `data` is a slice of functions that return values
-	// Note that its uses the expected signature `func() (interface{}, error) {...}`
-	data := []interface{}{
-		func() (interface{}, error) {
+	// Note that its uses the expected signature `func() (any, error) {...}`
+	data := []any{
+		func() (any, error) {
 			return 1, nil
 		},
-		func() (interface{}, error) {
+		func() (any, error) {
 			return nil, nil
 		},
-		func() (interface{}, error) {
+		func() (any, error) {
 			return 2, nil
 		},
 	}
@@ -811,7 +811,7 @@ func TestLists_NonNullListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
 			// we are not able to traverse up the tree until we find a nullable type,
 			// so in this case the entire data is nil. Will need some significant code
 			// restructure to restore this.
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"nest": nil,
 			},
 		*/
@@ -825,7 +825,7 @@ func TestLists_NonNullListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
 						Column: 10,
 					},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest",
 					"test",
 					1,
@@ -840,8 +840,8 @@ func TestLists_UserErrorExpectIterableButDidNotGetOne(t *testing.T) {
 	ttype := graphql.NewList(graphql.Int)
 	data := "Not an iterable"
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
 				"test": nil,
 			},
 		},
@@ -854,7 +854,7 @@ func TestLists_UserErrorExpectIterableButDidNotGetOne(t *testing.T) {
 						Column: 10,
 					},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest",
 					"test",
 				},
@@ -866,13 +866,13 @@ func TestLists_UserErrorExpectIterableButDidNotGetOne(t *testing.T) {
 
 func TestLists_ArrayOfNullableObjects_ContainsValues(t *testing.T) {
 	ttype := graphql.NewList(graphql.Int)
-	data := [2]interface{}{
+	data := [2]any{
 		1, 2,
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
+				"test": []any{
 					1, 2,
 				},
 			},
@@ -888,7 +888,7 @@ func TestLists_ValueMayBeNilPointer(t *testing.T) {
 			Fields: graphql.Fields{
 				"list": &graphql.Field{
 					Type: graphql.NewList(graphql.Int),
-					Resolve: func(_ graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(_ graphql.ResolveParams) (any, error) {
 						return []int(nil), nil
 					},
 				},
@@ -897,8 +897,8 @@ func TestLists_ValueMayBeNilPointer(t *testing.T) {
 	})
 	query := "{ list }"
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"list": []interface{}{},
+		Data: map[string]any{
+			"list": []any{},
 		},
 	}
 	result := g(t, graphql.Params{
@@ -915,8 +915,8 @@ func TestLists_NullableListOfInt_ReturnsNull(t *testing.T) {
 	type dataType *[]int
 	var data dataType
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
 				"test": nil,
 			},
 		},

--- a/located.go
+++ b/located.go
@@ -7,15 +7,15 @@ import (
 	"github.com/machship/graphql/language/ast"
 )
 
-func NewLocatedError(err interface{}, nodes []ast.Node) *gqlerrors.Error {
+func NewLocatedError(err any, nodes []ast.Node) *gqlerrors.Error {
 	return newLocatedError(err, nodes, nil)
 }
 
-func NewLocatedErrorWithPath(err interface{}, nodes []ast.Node, path []interface{}) *gqlerrors.Error {
+func NewLocatedErrorWithPath(err any, nodes []ast.Node, path []any) *gqlerrors.Error {
 	return newLocatedError(err, nodes, path)
 }
 
-func newLocatedError(err interface{}, nodes []ast.Node, path []interface{}) *gqlerrors.Error {
+func newLocatedError(err any, nodes []ast.Node, path []any) *gqlerrors.Error {
 	if err, ok := err.(*gqlerrors.Error); ok {
 		return err
 	}

--- a/mutations_test.go
+++ b/mutations_test.go
@@ -172,7 +172,7 @@ func TestMutations_ExecutionOrdering_EvaluatesMutationsSerially(t *testing.T) {
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -246,7 +246,7 @@ func TestMutations_EvaluatesMutationsCorrectlyInThePresenceOfAFailedMutation(t *
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
 	t.Skipf("Testing equality for slice of errors in results")
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }

--- a/mutations_test.go
+++ b/mutations_test.go
@@ -66,7 +66,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
@@ -80,7 +80,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
@@ -94,7 +94,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
@@ -108,7 +108,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
@@ -141,20 +141,20 @@ func TestMutations_ExecutionOrdering_EvaluatesMutationsSerially(t *testing.T) {
     }`
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"first": map[string]interface{}{
+		Data: map[string]any{
+			"first": map[string]any{
 				"theNumber": 1,
 			},
-			"second": map[string]interface{}{
+			"second": map[string]any{
 				"theNumber": 2,
 			},
-			"third": map[string]interface{}{
+			"third": map[string]any{
 				"theNumber": 3,
 			},
-			"fourth": map[string]interface{}{
+			"fourth": map[string]any{
 				"theNumber": 4,
 			},
-			"fifth": map[string]interface{}{
+			"fifth": map[string]any{
 				"theNumber": 5,
 			},
 		},
@@ -201,18 +201,18 @@ func TestMutations_EvaluatesMutationsCorrectlyInThePresenceOfAFailedMutation(t *
     }`
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"first": map[string]interface{}{
+		Data: map[string]any{
+			"first": map[string]any{
 				"theNumber": 1,
 			},
-			"second": map[string]interface{}{
+			"second": map[string]any{
 				"theNumber": 2,
 			},
 			"third": nil,
-			"fourth": map[string]interface{}{
+			"fourth": map[string]any{
 				"theNumber": 4,
 			},
-			"fifth": map[string]interface{}{
+			"fifth": map[string]any{
 				"theNumber": 5,
 			},
 			"sixth": nil,

--- a/nonnull_test.go
+++ b/nonnull_test.go
@@ -15,32 +15,32 @@ var nonNullSyncError = "nonNullSync"
 var promiseError = "promise"
 var nonNullPromiseError = "nonNullPromise"
 
-var throwingData = map[string]interface{}{
-	"sync": func() interface{} {
+var throwingData = map[string]any{
+	"sync": func() any {
 		panic(syncError)
 	},
-	"nonNullSync": func() interface{} {
+	"nonNullSync": func() any {
 		panic(nonNullSyncError)
 	},
-	"promise": func() interface{} {
+	"promise": func() any {
 		panic(promiseError)
 	},
-	"nonNullPromise": func() interface{} {
+	"nonNullPromise": func() any {
 		panic(nonNullPromiseError)
 	},
 }
 
-var nullingData = map[string]interface{}{
-	"sync": func() interface{} {
+var nullingData = map[string]any{
+	"sync": func() any {
 		return nil
 	},
-	"nonNullSync": func() interface{} {
+	"nonNullSync": func() any {
 		return nil
 	},
-	"promise": func() interface{} {
+	"promise": func() any {
 		return nil
 	},
-	"nonNullPromise": func() interface{} {
+	"nonNullPromise": func() any {
 		return nil
 	},
 }
@@ -68,29 +68,29 @@ var nonNullTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 })
 
 func init() {
-	throwingData["nest"] = func() interface{} {
+	throwingData["nest"] = func() any {
 		return throwingData
 	}
-	throwingData["nonNullNest"] = func() interface{} {
+	throwingData["nonNullNest"] = func() any {
 		return throwingData
 	}
-	throwingData["promiseNest"] = func() interface{} {
+	throwingData["promiseNest"] = func() any {
 		return throwingData
 	}
-	throwingData["nonNullPromiseNest"] = func() interface{} {
+	throwingData["nonNullPromiseNest"] = func() any {
 		return throwingData
 	}
 
-	nullingData["nest"] = func() interface{} {
+	nullingData["nest"] = func() any {
 		return nullingData
 	}
-	nullingData["nonNullNest"] = func() interface{} {
+	nullingData["nonNullNest"] = func() any {
 		return nullingData
 	}
-	nullingData["promiseNest"] = func() interface{} {
+	nullingData["promiseNest"] = func() any {
 		return nullingData
 	}
-	nullingData["nonNullPromiseNest"] = func() interface{} {
+	nullingData["nonNullPromiseNest"] = func() any {
 		return nullingData
 	}
 
@@ -116,7 +116,7 @@ func TestNonNull_NullsANullableFieldThatThrowsSynchronously(t *testing.T) {
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"sync": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -127,7 +127,7 @@ func TestNonNull_NullsANullableFieldThatThrowsSynchronously(t *testing.T) {
 						Line: 3, Column: 9,
 					},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"sync",
 				},
 			},
@@ -154,7 +154,7 @@ func TestNonNull_NullsANullableFieldThatThrowsInAPromise(t *testing.T) {
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"promise": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -165,7 +165,7 @@ func TestNonNull_NullsANullableFieldThatThrowsInAPromise(t *testing.T) {
 						Line: 3, Column: 9,
 					},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"promise",
 				},
 			},
@@ -194,7 +194,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANullableFieldThat
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"nest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -205,7 +205,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANullableFieldThat
 						Line: 4, Column: 11,
 					},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest",
 					"nonNullSync",
 				},
@@ -235,7 +235,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"nest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -246,7 +246,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
 						Line: 4, Column: 11,
 					},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest",
 					"nonNullPromise",
 				},
@@ -276,7 +276,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"promiseNest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -287,7 +287,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 						Line: 4, Column: 11,
 					},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"promiseNest",
 					"nonNullSync",
 				},
@@ -317,7 +317,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"promiseNest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -328,7 +328,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 						Line: 4, Column: 11,
 					},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"promiseNest",
 					"nonNullPromise",
 				},
@@ -380,27 +380,27 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
 				"sync":    nil,
 				"promise": nil,
-				"nest": map[string]interface{}{
+				"nest": map[string]any{
 					"sync":    nil,
 					"promise": nil,
 				},
-				"promiseNest": map[string]interface{}{
+				"promiseNest": map[string]any{
 					"sync":    nil,
 					"promise": nil,
 				},
 			},
-			"promiseNest": map[string]interface{}{
+			"promiseNest": map[string]any{
 				"sync":    nil,
 				"promise": nil,
-				"nest": map[string]interface{}{
+				"nest": map[string]any{
 					"sync":    nil,
 					"promise": nil,
 				},
-				"promiseNest": map[string]interface{}{
+				"promiseNest": map[string]any{
 					"sync":    nil,
 					"promise": nil,
 				},
@@ -412,7 +412,7 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
 				Locations: []location.SourceLocation{
 					{Line: 4, Column: 11},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest", "sync",
 				},
 			}),
@@ -421,7 +421,7 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
 				Locations: []location.SourceLocation{
 					{Line: 7, Column: 13},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest", "nest", "sync",
 				},
 			}),
@@ -430,7 +430,7 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
 				Locations: []location.SourceLocation{
 					{Line: 11, Column: 13},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest", "promiseNest", "sync",
 				},
 			}),
@@ -439,7 +439,7 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
 				Locations: []location.SourceLocation{
 					{Line: 16, Column: 11},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"promiseNest", "sync",
 				},
 			}),
@@ -448,7 +448,7 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
 				Locations: []location.SourceLocation{
 					{Line: 19, Column: 13},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"promiseNest", "nest", "sync",
 				},
 			}),
@@ -457,7 +457,7 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
 				Locations: []location.SourceLocation{
 					{Line: 23, Column: 13},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"promiseNest", "promiseNest", "sync",
 				},
 			}),
@@ -466,7 +466,7 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
 				Locations: []location.SourceLocation{
 					{Line: 5, Column: 11},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest", "promise",
 				},
 			}),
@@ -475,7 +475,7 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
 				Locations: []location.SourceLocation{
 					{Line: 8, Column: 13},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest", "nest", "promise",
 				},
 			}),
@@ -484,7 +484,7 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
 				Locations: []location.SourceLocation{
 					{Line: 12, Column: 13},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest", "promiseNest", "promise",
 				},
 			}),
@@ -493,7 +493,7 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
 				Locations: []location.SourceLocation{
 					{Line: 17, Column: 11},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"promiseNest", "promise",
 				},
 			}),
@@ -502,7 +502,7 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
 				Locations: []location.SourceLocation{
 					{Line: 20, Column: 13},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"promiseNest", "nest", "promise",
 				},
 			}),
@@ -511,7 +511,7 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
 				Locations: []location.SourceLocation{
 					{Line: 24, Column: 13},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"promiseNest", "promiseNest", "promise",
 				},
 			}),
@@ -583,7 +583,7 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"nest":               nil,
 			"promiseNest":        nil,
 			"anotherNest":        nil,
@@ -595,7 +595,7 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
 				Locations: []location.SourceLocation{
 					{Line: 8, Column: 19},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
 					"nonNullPromiseNest", "nonNullSync",
 				},
@@ -605,7 +605,7 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
 				Locations: []location.SourceLocation{
 					{Line: 19, Column: 19},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"promiseNest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
 					"nonNullPromiseNest", "nonNullSync",
 				},
@@ -615,7 +615,7 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
 				Locations: []location.SourceLocation{
 					{Line: 30, Column: 19},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"anotherNest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
 					"nonNullPromiseNest", "nonNullPromise",
 				},
@@ -625,7 +625,7 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
 				Locations: []location.SourceLocation{
 					{Line: 41, Column: 19},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"anotherPromiseNest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
 					"nonNullPromiseNest", "nonNullPromise",
 				},
@@ -656,7 +656,7 @@ func TestNonNull_NullsANullableFieldThatSynchronouslyReturnsNull(t *testing.T) {
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"sync": nil,
 		},
 	}
@@ -681,7 +681,7 @@ func TestNonNull_NullsANullableFieldThatSynchronouslyReturnsNullInAPromise(t *te
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"promise": nil,
 		},
 	}
@@ -708,7 +708,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"nest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -717,7 +717,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
 				Locations: []location.SourceLocation{
 					{Line: 4, Column: 11},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest",
 					"nonNullSync",
 				},
@@ -747,7 +747,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"nest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -756,7 +756,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
 				Locations: []location.SourceLocation{
 					{Line: 4, Column: 11},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest",
 					"nonNullPromise",
 				},
@@ -787,7 +787,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"promiseNest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -796,7 +796,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 				Locations: []location.SourceLocation{
 					{Line: 4, Column: 11},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"promiseNest",
 					"nonNullSync",
 				},
@@ -826,7 +826,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"promiseNest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -835,7 +835,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 				Locations: []location.SourceLocation{
 					{Line: 4, Column: 11},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"promiseNest",
 					"nonNullPromise",
 				},
@@ -886,27 +886,27 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatReturnNull(t *testing.T) {
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
+		Data: map[string]any{
+			"nest": map[string]any{
 				"sync":    nil,
 				"promise": nil,
-				"nest": map[string]interface{}{
+				"nest": map[string]any{
 					"sync":    nil,
 					"promise": nil,
 				},
-				"promiseNest": map[string]interface{}{
+				"promiseNest": map[string]any{
 					"sync":    nil,
 					"promise": nil,
 				},
 			},
-			"promiseNest": map[string]interface{}{
+			"promiseNest": map[string]any{
 				"sync":    nil,
 				"promise": nil,
-				"nest": map[string]interface{}{
+				"nest": map[string]any{
 					"sync":    nil,
 					"promise": nil,
 				},
-				"promiseNest": map[string]interface{}{
+				"promiseNest": map[string]any{
 					"sync":    nil,
 					"promise": nil,
 				},
@@ -977,7 +977,7 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldReturnsNullInALongChainOf
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"nest":               nil,
 			"promiseNest":        nil,
 			"anotherNest":        nil,
@@ -989,7 +989,7 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldReturnsNullInALongChainOf
 				Locations: []location.SourceLocation{
 					{Line: 8, Column: 19},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
 					"nonNullPromiseNest", "nonNullSync",
 				},
@@ -999,7 +999,7 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldReturnsNullInALongChainOf
 				Locations: []location.SourceLocation{
 					{Line: 19, Column: 19},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"promiseNest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
 					"nonNullPromiseNest", "nonNullSync",
 				},
@@ -1009,7 +1009,7 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldReturnsNullInALongChainOf
 				Locations: []location.SourceLocation{
 					{Line: 30, Column: 19},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"anotherNest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
 					"nonNullPromiseNest", "nonNullPromise",
 				},
@@ -1019,7 +1019,7 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldReturnsNullInALongChainOf
 				Locations: []location.SourceLocation{
 					{Line: 41, Column: 19},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"anotherPromiseNest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
 					"nonNullPromiseNest", "nonNullPromise",
 				},
@@ -1055,7 +1055,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldThrows(t *testing.T) {
 				Locations: []location.SourceLocation{
 					{Line: 2, Column: 17},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nonNullSync",
 				},
 			},
@@ -1087,7 +1087,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldErrors(t *testing.T) {
 				Locations: []location.SourceLocation{
 					{Line: 2, Column: 17},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nonNullPromise",
 				},
 			},
@@ -1119,7 +1119,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldReturnsNull(t *testing.T)
 				Locations: []location.SourceLocation{
 					{Line: 2, Column: 17},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nonNullSync",
 				},
 			},
@@ -1151,7 +1151,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldResolvesNull(t *testing.T
 				Locations: []location.SourceLocation{
 					{Line: 2, Column: 17},
 				},
-				Path: []interface{}{
+				Path: []any{
 					"nonNullPromise",
 				},
 			},

--- a/race_test.go
+++ b/race_test.go
@@ -38,7 +38,7 @@ func TestRace(t *testing.T) {
 							Fields: graphql.Fields{
 								"hello": &graphql.Field{
 									Type: graphql.String,
-									Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+									Resolve: func(p graphql.ResolveParams) (any, error) {
 										return "world", nil
 									},
 								},

--- a/race_test.go
+++ b/race_test.go
@@ -9,6 +9,9 @@ import (
 
 func TestRace(t *testing.T) {
 	tempdir := filepath.Join(os.TempDir(), "race")
+	if err := os.MkdirAll(tempdir, 0755); err != nil {
+		t.Fatalf("Failed to create temporary directory: %s", err)
+	}
 	defer os.RemoveAll(tempdir)
 
 	filename := filepath.Join(tempdir, "example.go")

--- a/race_test.go
+++ b/race_test.go
@@ -1,7 +1,6 @@
 package graphql_test
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -9,14 +8,11 @@ import (
 )
 
 func TestRace(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "race")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tempdir := filepath.Join(os.TempDir(), "race")
 	defer os.RemoveAll(tempdir)
 
 	filename := filepath.Join(tempdir, "example.go")
-	err = ioutil.WriteFile(filename, []byte(`
+	err := os.WriteFile(filename, []byte(`
 		package main
 
 		import (

--- a/rules.go
+++ b/rules.go
@@ -234,7 +234,7 @@ func FieldsOnCorrectTypeRule(context *ValidationContext) *ValidationRuleInstance
 							// If there are no suggested types, then perhaps this was a typo?
 							suggestedFieldNames := []string{}
 							if len(suggestedTypeNames) == 0 {
-								suggestedFieldNames = getSuggestedFieldNames(context.Schema(), ttype, nodeName)
+								suggestedFieldNames = getSuggestedFieldNames(ttype, nodeName)
 							}
 							reportError(
 								context,
@@ -323,9 +323,9 @@ func getSuggestedTypeNames(schema *Schema, ttype Output, fieldName string) []str
 
 // getSuggestedFieldNames For the field name provided, determine if there are any similar field names
 // that may be the result of a typo.
-func getSuggestedFieldNames(schema *Schema, ttype Output, fieldName string) []string {
+func getSuggestedFieldNames(ttype Output, fieldName string) []string {
 
-	fields := FieldDefinitionMap{}
+	var fields FieldDefinitionMap
 	switch ttype := ttype.(type) {
 	case *Object:
 		fields = ttype.Fields()
@@ -1043,7 +1043,7 @@ func NoUnusedFragmentsRule(context *ValidationContext) *ValidationRuleInstance {
 						}
 
 						isFragNameUsed, ok := fragmentNameUsed[defName]
-						if !ok || isFragNameUsed != true {
+						if !ok || !isFragNameUsed {
 							reportError(
 								context,
 								fmt.Sprintf(`Fragment "%v" is never used.`, defName),
@@ -1176,7 +1176,7 @@ func doTypesOverlap(schema *Schema, t1 Type, t2 Type) bool {
 		}
 		if t2, ok := t2.(Abstract); ok {
 			for _, ttype := range schema.PossibleTypes(t2) {
-				if hasT1TypeName, _ := t1TypeNames[ttype.Name()]; hasT1TypeName {
+				if hasT1TypeName := t1TypeNames[ttype.Name()]; hasT1TypeName {
 					return true
 				}
 			}
@@ -1269,7 +1269,7 @@ func ProvidedNonNullArgumentsRule(context *ValidationContext) *ValidationRuleIns
 							argASTMap[name] = arg
 						}
 						for _, argDef := range fieldDef.Args {
-							argAST, _ := argASTMap[argDef.Name()]
+							argAST := argASTMap[argDef.Name()]
 							if argAST == nil {
 								if argDefType, ok := argDef.Type.(*NonNull); ok {
 									fieldName := ""
@@ -1310,7 +1310,7 @@ func ProvidedNonNullArgumentsRule(context *ValidationContext) *ValidationRuleIns
 						}
 
 						for _, argDef := range directiveDef.Args {
-							argAST, _ := argASTMap[argDef.Name()]
+							argAST := argASTMap[argDef.Name()]
 							if argAST == nil {
 								if argDefType, ok := argDef.Type.(*NonNull); ok {
 									directiveName := ""
@@ -1677,7 +1677,7 @@ func VariablesInAllowedPositionRule(context *ValidationContext) *ValidationRuleI
 							if usage != nil && usage.Node != nil && usage.Node.Name != nil {
 								varName = usage.Node.Name.Value
 							}
-							varDef, _ := varDefMap[varName]
+							varDef := varDefMap[varName]
 							if varDef != nil && usage.Type != nil {
 								varType, err := typeFromAST(*context.Schema(), varDef.Type)
 								if err != nil {

--- a/rules.go
+++ b/rules.go
@@ -58,7 +58,7 @@ func newValidationError(message string, nodes []ast.Node) *gqlerrors.Error {
 	)
 }
 
-func reportError(context *ValidationContext, message string, nodes []ast.Node) (string, interface{}) {
+func reportError(context *ValidationContext, message string, nodes []ast.Node) (string, any) {
 	context.ReportError(newValidationError(message, nodes))
 	return visitor.ActionNoChange, nil
 }
@@ -71,7 +71,7 @@ func ArgumentsOfCorrectTypeRule(context *ValidationContext) *ValidationRuleInsta
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.Argument: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if argAST, ok := p.Node.(*ast.Argument); ok {
 						if argDef := context.Argument(); argDef != nil {
 							if isValid, messages := isValidLiteralValue(argDef.Type, argAST.Value); !isValid {
@@ -111,7 +111,7 @@ func DefaultValuesOfCorrectTypeRule(context *ValidationContext) *ValidationRuleI
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.VariableDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if varDefAST, ok := p.Node.(*ast.VariableDefinition); ok {
 						var (
 							name         string
@@ -148,12 +148,12 @@ func DefaultValuesOfCorrectTypeRule(context *ValidationContext) *ValidationRuleI
 				},
 			},
 			kinds.SelectionSet: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					return visitor.ActionSkip, nil
 				},
 			},
 			kinds.FragmentDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					return visitor.ActionSkip, nil
 				},
 			},
@@ -208,7 +208,7 @@ func FieldsOnCorrectTypeRule(context *ValidationContext) *ValidationRuleInstance
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.Field: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					var action = visitor.ActionNoChange
 					if node, ok := p.Node.(*ast.Field); ok {
 						var ttype Composite
@@ -371,7 +371,7 @@ func FragmentsOnCompositeTypesRule(context *ValidationContext) *ValidationRuleIn
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.InlineFragment: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.InlineFragment); ok {
 						ttype := context.Type()
 						if node.TypeCondition != nil && ttype != nil && !IsCompositeType(ttype) {
@@ -386,7 +386,7 @@ func FragmentsOnCompositeTypesRule(context *ValidationContext) *ValidationRuleIn
 				},
 			},
 			kinds.FragmentDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.FragmentDefinition); ok {
 						ttype := context.Type()
 						if ttype != nil && !IsCompositeType(ttype) {
@@ -439,7 +439,7 @@ func KnownArgumentNamesRule(context *ValidationContext) *ValidationRuleInstance 
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.Argument: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					var action = visitor.ActionNoChange
 					if node, ok := p.Node.(*ast.Argument); ok {
 						var argumentOf ast.Node
@@ -531,9 +531,9 @@ func KnownDirectivesRule(context *ValidationContext) *ValidationRuleInstance {
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.Directive: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					var action = visitor.ActionNoChange
-					var result interface{}
+					var result any
 					if node, ok := p.Node.(*ast.Directive); ok {
 
 						nodeName := ""
@@ -672,9 +672,9 @@ func KnownFragmentNamesRule(context *ValidationContext) *ValidationRuleInstance 
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.FragmentSpread: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					var action = visitor.ActionNoChange
-					var result interface{}
+					var result any
 					if node, ok := p.Node.(*ast.FragmentSpread); ok {
 
 						fragmentName := ""
@@ -718,27 +718,27 @@ func KnownTypeNamesRule(context *ValidationContext) *ValidationRuleInstance {
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.ObjectDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					return visitor.ActionSkip, nil
 				},
 			},
 			kinds.InterfaceDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					return visitor.ActionSkip, nil
 				},
 			},
 			kinds.UnionDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					return visitor.ActionSkip, nil
 				},
 			},
 			kinds.InputObjectDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					return visitor.ActionSkip, nil
 				},
 			},
 			kinds.Named: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.Named); ok {
 						typeNameValue := ""
 						typeName := node.Name
@@ -777,7 +777,7 @@ func LoneAnonymousOperationRule(context *ValidationContext) *ValidationRuleInsta
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.Document: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.Document); ok {
 						operationCount = 0
 						for _, definition := range node.Definitions {
@@ -790,7 +790,7 @@ func LoneAnonymousOperationRule(context *ValidationContext) *ValidationRuleInsta
 				},
 			},
 			kinds.OperationDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.OperationDefinition); ok {
 						if node.Name == nil && operationCount > 1 {
 							reportError(
@@ -899,12 +899,12 @@ func NoFragmentCyclesRule(context *ValidationContext) *ValidationRuleInstance {
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.OperationDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					return visitor.ActionSkip, nil
 				},
 			},
 			kinds.FragmentDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.FragmentDefinition); ok && node != nil {
 						nodeName := ""
 						if node.Name != nil {
@@ -941,11 +941,11 @@ func NoUndefinedVariablesRule(context *ValidationContext) *ValidationRuleInstanc
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.OperationDefinition: {
-				Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Enter: func(p visitor.VisitFuncParams) (string, any) {
 					variableNameDefined = map[string]bool{}
 					return visitor.ActionNoChange, nil
 				},
-				Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Leave: func(p visitor.VisitFuncParams) (string, any) {
 					if operation, ok := p.Node.(*ast.OperationDefinition); ok && operation != nil {
 						usages := context.RecursiveVariableUsages(operation)
 
@@ -977,7 +977,7 @@ func NoUndefinedVariablesRule(context *ValidationContext) *ValidationRuleInstanc
 				},
 			},
 			kinds.VariableDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.VariableDefinition); ok && node != nil {
 						variableName := ""
 						if node.Variable != nil && node.Variable.Name != nil {
@@ -1007,7 +1007,7 @@ func NoUnusedFragmentsRule(context *ValidationContext) *ValidationRuleInstance {
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.OperationDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.OperationDefinition); ok && node != nil {
 						operationDefs = append(operationDefs, node)
 					}
@@ -1015,7 +1015,7 @@ func NoUnusedFragmentsRule(context *ValidationContext) *ValidationRuleInstance {
 				},
 			},
 			kinds.FragmentDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.FragmentDefinition); ok && node != nil {
 						fragmentDefs = append(fragmentDefs, node)
 					}
@@ -1023,7 +1023,7 @@ func NoUnusedFragmentsRule(context *ValidationContext) *ValidationRuleInstance {
 				},
 			},
 			kinds.Document: {
-				Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Leave: func(p visitor.VisitFuncParams) (string, any) {
 					fragmentNameUsed := map[string]bool{}
 					for _, operation := range operationDefs {
 						fragments := context.RecursivelyReferencedFragments(operation)
@@ -1079,11 +1079,11 @@ func NoUnusedVariablesRule(context *ValidationContext) *ValidationRuleInstance {
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.OperationDefinition: {
-				Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Enter: func(p visitor.VisitFuncParams) (string, any) {
 					variableDefs = []*ast.VariableDefinition{}
 					return visitor.ActionNoChange, nil
 				},
-				Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Leave: func(p visitor.VisitFuncParams) (string, any) {
 					if operation, ok := p.Node.(*ast.OperationDefinition); ok && operation != nil {
 						variableNameUsed := map[string]bool{}
 						usages := context.RecursiveVariableUsages(operation)
@@ -1121,7 +1121,7 @@ func NoUnusedVariablesRule(context *ValidationContext) *ValidationRuleInstance {
 				},
 			},
 			kinds.VariableDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if def, ok := p.Node.(*ast.VariableDefinition); ok && def != nil {
 						variableDefs = append(variableDefs, def)
 					}
@@ -1196,7 +1196,7 @@ func PossibleFragmentSpreadsRule(context *ValidationContext) *ValidationRuleInst
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.InlineFragment: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.InlineFragment); ok && node != nil {
 						fragType := context.Type()
 						parentType, _ := context.ParentType().(Type)
@@ -1214,7 +1214,7 @@ func PossibleFragmentSpreadsRule(context *ValidationContext) *ValidationRuleInst
 				},
 			},
 			kinds.FragmentSpread: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.FragmentSpread); ok && node != nil {
 						fragName := ""
 						if node.Name != nil {
@@ -1250,7 +1250,7 @@ func ProvidedNonNullArgumentsRule(context *ValidationContext) *ValidationRuleIns
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.Field: {
-				Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Leave: func(p visitor.VisitFuncParams) (string, any) {
 					// Validate on leave to allow for deeper errors to appear first.
 					if fieldAST, ok := p.Node.(*ast.Field); ok && fieldAST != nil {
 						fieldDef := context.FieldDef()
@@ -1290,7 +1290,7 @@ func ProvidedNonNullArgumentsRule(context *ValidationContext) *ValidationRuleIns
 				},
 			},
 			kinds.Directive: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					// Validate on leave to allow for deeper errors to appear first.
 
 					if directiveAST, ok := p.Node.(*ast.Directive); ok && directiveAST != nil {
@@ -1346,7 +1346,7 @@ func ScalarLeafsRule(context *ValidationContext) *ValidationRuleInstance {
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.Field: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.Field); ok && node != nil {
 						nodeName := ""
 						if node.Name != nil {
@@ -1391,19 +1391,19 @@ func UniqueArgumentNamesRule(context *ValidationContext) *ValidationRuleInstance
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.Field: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					knownArgNames = map[string]*ast.Name{}
 					return visitor.ActionNoChange, nil
 				},
 			},
 			kinds.Directive: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					knownArgNames = map[string]*ast.Name{}
 					return visitor.ActionNoChange, nil
 				},
 			},
 			kinds.Argument: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.Argument); ok {
 						argName := ""
 						if node.Name != nil {
@@ -1438,12 +1438,12 @@ func UniqueFragmentNamesRule(context *ValidationContext) *ValidationRuleInstance
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.OperationDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					return visitor.ActionSkip, nil
 				},
 			},
 			kinds.FragmentDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.FragmentDefinition); ok && node != nil {
 						fragmentName := ""
 						if node.Name != nil {
@@ -1480,19 +1480,19 @@ func UniqueInputFieldNamesRule(context *ValidationContext) *ValidationRuleInstan
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.ObjectValue: {
-				Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Enter: func(p visitor.VisitFuncParams) (string, any) {
 					knownNameStack = append(knownNameStack, knownNames)
 					knownNames = map[string]*ast.Name{}
 					return visitor.ActionNoChange, nil
 				},
-				Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Leave: func(p visitor.VisitFuncParams) (string, any) {
 					// pop
 					knownNames, knownNameStack = knownNameStack[len(knownNameStack)-1], knownNameStack[:len(knownNameStack)-1]
 					return visitor.ActionNoChange, nil
 				},
 			},
 			kinds.ObjectField: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.ObjectField); ok {
 						fieldName := ""
 						if node.Name != nil {
@@ -1528,7 +1528,7 @@ func UniqueOperationNamesRule(context *ValidationContext) *ValidationRuleInstanc
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.OperationDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.OperationDefinition); ok && node != nil {
 						operationName := ""
 						if node.Name != nil {
@@ -1552,7 +1552,7 @@ func UniqueOperationNamesRule(context *ValidationContext) *ValidationRuleInstanc
 				},
 			},
 			kinds.FragmentDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					return visitor.ActionSkip, nil
 				},
 			},
@@ -1572,7 +1572,7 @@ func UniqueVariableNamesRule(context *ValidationContext) *ValidationRuleInstance
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.OperationDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.OperationDefinition); ok && node != nil {
 						knownVariableNames = map[string]*ast.Name{}
 					}
@@ -1580,7 +1580,7 @@ func UniqueVariableNamesRule(context *ValidationContext) *ValidationRuleInstance
 				},
 			},
 			kinds.VariableDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.VariableDefinition); ok && node != nil {
 						variableName := ""
 						var variableNameAST *ast.Name
@@ -1617,7 +1617,7 @@ func VariablesAreInputTypesRule(context *ValidationContext) *ValidationRuleInsta
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.VariableDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.VariableDefinition); ok && node != nil {
 						ttype, _ := typeFromAST(*context.Schema(), node.Type)
 
@@ -1664,11 +1664,11 @@ func VariablesInAllowedPositionRule(context *ValidationContext) *ValidationRuleI
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.OperationDefinition: {
-				Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Enter: func(p visitor.VisitFuncParams) (string, any) {
 					varDefMap = map[string]*ast.VariableDefinition{}
 					return visitor.ActionNoChange, nil
 				},
-				Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Leave: func(p visitor.VisitFuncParams) (string, any) {
 					if operation, ok := p.Node.(*ast.OperationDefinition); ok {
 
 						usages := context.RecursiveVariableUsages(operation)
@@ -1699,7 +1699,7 @@ func VariablesInAllowedPositionRule(context *ValidationContext) *ValidationRuleI
 				},
 			},
 			kinds.VariableDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if varDefAST, ok := p.Node.(*ast.VariableDefinition); ok {
 						defName := ""
 						if varDefAST.Variable != nil && varDefAST.Variable.Name != nil {

--- a/rules_overlapping_fields_can_be_merged.go
+++ b/rules_overlapping_fields_can_be_merged.go
@@ -468,10 +468,10 @@ func (rule *overlappingFieldsCanBeMergedRule) getFieldsAndFragmentNames(parentTy
 				}
 				var fieldDef *FieldDefinition
 				if parentType, ok := parentType.(*Object); ok && parentType != nil {
-					fieldDef, _ = parentType.Fields()[fieldName]
+					fieldDef = parentType.Fields()[fieldName]
 				}
 				if parentType, ok := parentType.(*Interface); ok && parentType != nil {
-					fieldDef, _ = parentType.Fields()[fieldName]
+					fieldDef = parentType.Fields()[fieldName]
 				}
 
 				responseName := fieldName
@@ -586,7 +586,7 @@ func (pair *pairSet) Has(a string, b string, areMutuallyExclusive bool) bool {
 	// hence if we want to know if this PairSet "has" these two with no
 	// exclusivity, we have to ensure it was added as such.
 	if !areMutuallyExclusive {
-		return res == false
+		return !res
 	}
 	return true
 }
@@ -629,7 +629,7 @@ func sameArguments(args1 []*ast.Argument, args2 []*ast.Argument) bool {
 		if foundArgs2 == nil {
 			return false
 		}
-		if sameValue(arg1.Value, foundArgs2.Value) == false {
+		if !sameValue(arg1.Value, foundArgs2.Value) {
 			return false
 		}
 	}

--- a/rules_overlapping_fields_can_be_merged.go
+++ b/rules_overlapping_fields_can_be_merged.go
@@ -18,7 +18,7 @@ func fieldsConflictMessage(responseName string, reason conflictReason) string {
 	)
 }
 
-func fieldsConflictReasonMessage(message interface{}) string {
+func fieldsConflictReasonMessage(message any) string {
 	switch reason := message.(type) {
 	case string:
 		return reason
@@ -58,7 +58,7 @@ func OverlappingFieldsCanBeMergedRule(context *ValidationContext) *ValidationRul
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.SelectionSet: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if selectionSet, ok := p.Node.(*ast.SelectionSet); ok && selectionSet != nil {
 						parentType, _ := context.ParentType().(Named)
 
@@ -539,7 +539,7 @@ func (rule *overlappingFieldsCanBeMergedRule) getReferencedFieldsAndFragmentName
 
 type conflictReason struct {
 	Name    string
-	Message interface{} // conflictReason || []conflictReason
+	Message any // conflictReason || []conflictReason
 }
 type conflict struct {
 	Reason      conflictReason

--- a/scalars.go
+++ b/scalars.go
@@ -17,7 +17,7 @@ import (
 func coerceInt(value any) any {
 	switch value := value.(type) {
 	case bool:
-		if value == true {
+		if value {
 			return 1
 		}
 		return 0
@@ -132,7 +132,7 @@ func coerceInt(value any) any {
 		}
 		return coerceInt(*value)
 	case string:
-		val, err := strconv.ParseFloat(value, 0)
+		val, err := strconv.ParseFloat(value, 64)
 		if err != nil {
 			return nil
 		}
@@ -170,7 +170,7 @@ var Int = NewScalar(ScalarConfig{
 func coerceFloat(value any) any {
 	switch value := value.(type) {
 	case bool:
-		if value == true {
+		if value {
 			return 1.0
 		}
 		return 0.0
@@ -264,7 +264,7 @@ func coerceFloat(value any) any {
 		}
 		return coerceFloat(*value)
 	case string:
-		val, err := strconv.ParseFloat(value, 0)
+		val, err := strconv.ParseFloat(value, 64)
 		if err != nil {
 			return nil
 		}

--- a/scalars.go
+++ b/scalars.go
@@ -14,7 +14,7 @@ import (
 //
 // n.b. JavaScript's integers are safe between -(2^53 - 1) and 2^53 - 1 because
 // they are internally represented as IEEE 754 doubles.
-func coerceInt(value interface{}) interface{} {
+func coerceInt(value any) any {
 	switch value := value.(type) {
 	case bool:
 		if value == true {
@@ -156,7 +156,7 @@ var Int = NewScalar(ScalarConfig{
 		"values. Int can represent values between -(2^31) and 2^31 - 1. ",
 	Serialize:  coerceInt,
 	ParseValue: coerceInt,
-	ParseLiteral: func(valueAST ast.Value) interface{} {
+	ParseLiteral: func(valueAST ast.Value) any {
 		switch valueAST := valueAST.(type) {
 		case *ast.IntValue:
 			if intValue, err := strconv.Atoi(valueAST.Value); err == nil {
@@ -167,7 +167,7 @@ var Int = NewScalar(ScalarConfig{
 	},
 })
 
-func coerceFloat(value interface{}) interface{} {
+func coerceFloat(value any) any {
 	switch value := value.(type) {
 	case bool:
 		if value == true {
@@ -289,7 +289,7 @@ var Float = NewScalar(ScalarConfig{
 		"[IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). ",
 	Serialize:  coerceFloat,
 	ParseValue: coerceFloat,
-	ParseLiteral: func(valueAST ast.Value) interface{} {
+	ParseLiteral: func(valueAST ast.Value) any {
 		switch valueAST := valueAST.(type) {
 		case *ast.FloatValue:
 			if floatValue, err := strconv.ParseFloat(valueAST.Value, 64); err == nil {
@@ -304,7 +304,7 @@ var Float = NewScalar(ScalarConfig{
 	},
 })
 
-func coerceString(value interface{}) interface{} {
+func coerceString(value any) any {
 	if v, ok := value.(*string); ok {
 		if v == nil {
 			return nil
@@ -322,7 +322,7 @@ var String = NewScalar(ScalarConfig{
 		"represent free-form human-readable text.",
 	Serialize:  coerceString,
 	ParseValue: coerceString,
-	ParseLiteral: func(valueAST ast.Value) interface{} {
+	ParseLiteral: func(valueAST ast.Value) any {
 		switch valueAST := valueAST.(type) {
 		case *ast.StringValue:
 			return valueAST.Value
@@ -331,7 +331,7 @@ var String = NewScalar(ScalarConfig{
 	},
 })
 
-func coerceBool(value interface{}) interface{} {
+func coerceBool(value any) any {
 	switch value := value.(type) {
 	case bool:
 		return value
@@ -481,7 +481,7 @@ var Boolean = NewScalar(ScalarConfig{
 	Description: "The `Boolean` scalar type represents `true` or `false`.",
 	Serialize:   coerceBool,
 	ParseValue:  coerceBool,
-	ParseLiteral: func(valueAST ast.Value) interface{} {
+	ParseLiteral: func(valueAST ast.Value) any {
 		switch valueAST := valueAST.(type) {
 		case *ast.BooleanValue:
 			return valueAST.Value
@@ -500,7 +500,7 @@ var ID = NewScalar(ScalarConfig{
 		"(such as `4`) input value will be accepted as an ID.",
 	Serialize:  coerceString,
 	ParseValue: coerceString,
-	ParseLiteral: func(valueAST ast.Value) interface{} {
+	ParseLiteral: func(valueAST ast.Value) any {
 		switch valueAST := valueAST.(type) {
 		case *ast.IntValue:
 			return valueAST.Value
@@ -511,7 +511,7 @@ var ID = NewScalar(ScalarConfig{
 	},
 })
 
-func serializeDateTime(value interface{}) interface{} {
+func serializeDateTime(value any) any {
 	switch value := value.(type) {
 	case time.Time:
 		buff, err := value.MarshalText()
@@ -530,7 +530,7 @@ func serializeDateTime(value interface{}) interface{} {
 	}
 }
 
-func unserializeDateTime(value interface{}) interface{} {
+func unserializeDateTime(value any) any {
 	switch value := value.(type) {
 	case []byte:
 		t := time.Time{}
@@ -560,7 +560,7 @@ var DateTime = NewScalar(ScalarConfig{
 		" The DateTime is serialized as an RFC 3339 quoted string",
 	Serialize:  serializeDateTime,
 	ParseValue: unserializeDateTime,
-	ParseLiteral: func(valueAST ast.Value) interface{} {
+	ParseLiteral: func(valueAST ast.Value) any {
 		switch valueAST := valueAST.(type) {
 		case *ast.StringValue:
 			return unserializeDateTime(valueAST.Value)

--- a/scalars_parse_test.go
+++ b/scalars_parse_test.go
@@ -31,7 +31,7 @@ func TestTypeSystem_Scalar_ParseLiteralOutputDateTime(t *testing.T) {
 	t1, _ := time.Parse(time.RFC3339, "2017-07-23T03:46:56.647Z")
 	for name, testCase := range map[string]struct {
 		Literal  ast.Value
-		Expected interface{}
+		Expected any
 	}{
 		"String": {
 			Literal: &ast.StringValue{

--- a/scalars_serialization_test.go
+++ b/scalars_serialization_test.go
@@ -10,27 +10,27 @@ import (
 )
 
 type intSerializationTest struct {
-	Value    interface{}
-	Expected interface{}
+	Value    any
+	Expected any
 }
 
 type float64SerializationTest struct {
-	Value    interface{}
-	Expected interface{}
+	Value    any
+	Expected any
 }
 
 type stringSerializationTest struct {
-	Value    interface{}
+	Value    any
 	Expected string
 }
 
 type dateTimeSerializationTest struct {
-	Value    interface{}
-	Expected interface{}
+	Value    any
+	Expected any
 }
 
 type boolSerializationTest struct {
-	Value    interface{}
+	Value    any
 	Expected bool
 }
 

--- a/scalars_test.go
+++ b/scalars_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestCoerceInt(t *testing.T) {
 	tests := []struct {
-		in   interface{}
-		want interface{}
+		in   any
+		want any
 	}{
 		{
 			in:   false,
@@ -237,7 +237,7 @@ func TestCoerceInt(t *testing.T) {
 			want: nil,
 		},
 		{
-			in:   make(map[string]interface{}),
+			in:   make(map[string]any),
 			want: nil,
 		},
 	}
@@ -251,8 +251,8 @@ func TestCoerceInt(t *testing.T) {
 
 func TestCoerceFloat(t *testing.T) {
 	tests := []struct {
-		in   interface{}
-		want interface{}
+		in   any
+		want any
 	}{
 		{
 			in:   false,
@@ -435,7 +435,7 @@ func TestCoerceFloat(t *testing.T) {
 			want: nil,
 		},
 		{
-			in:   make(map[string]interface{}),
+			in:   make(map[string]any),
 			want: nil,
 		},
 	}
@@ -449,8 +449,8 @@ func TestCoerceFloat(t *testing.T) {
 
 func TestCoerceBool(t *testing.T) {
 	tests := []struct {
-		in   interface{}
-		want interface{}
+		in   any
+		want any
 	}{
 		{
 			in:   false,
@@ -737,7 +737,7 @@ func TestCoerceBool(t *testing.T) {
 			want: false,
 		},
 		{
-			in:   make(map[string]interface{}),
+			in:   make(map[string]any),
 			want: false,
 		},
 	}

--- a/schema.go
+++ b/schema.go
@@ -16,21 +16,23 @@ type TypeMap map[string]Type
 // query, mutation (optional) and subscription (optional). A schema definition is then supplied to the
 // validator and executor.
 // Example:
-//     myAppSchema, err := NewSchema(SchemaConfig({
-//       Query: MyAppQueryRootType,
-//       Mutation: MyAppMutationRootType,
-//       Subscription: MyAppSubscriptionRootType,
-//     });
+//
+//	myAppSchema, err := NewSchema(SchemaConfig({
+//	  Query: MyAppQueryRootType,
+//	  Mutation: MyAppMutationRootType,
+//	  Subscription: MyAppSubscriptionRootType,
+//	});
+//
 // Note: If an array of `directives` are provided to GraphQLSchema, that will be
 // the exact list of directives represented and allowed. If `directives` is not
 // provided then a default set of the specified directives (e.g. @include and
 // @skip) will be used. If you wish to provide *additional* directives to these
 // specified directives, you must explicitly declare them. Example:
 //
-//     const MyAppSchema = new GraphQLSchema({
-//       ...
-//       directives: specifiedDirectives.concat([ myCustomDirective ]),
-//     })
+//	const MyAppSchema = new GraphQLSchema({
+//	  ...
+//	  directives: specifiedDirectives.concat([ myCustomDirective ]),
+//	})
 type Schema struct {
 	typeMap    TypeMap
 	directives []*Directive
@@ -92,10 +94,8 @@ func NewSchema(config SchemaConfig) (Schema, error) {
 		initialTypes = append(initialTypes, SchemaType)
 	}
 
-	for _, ttype := range config.Types {
-		// assume that user will never add a nil object to config
-		initialTypes = append(initialTypes, ttype)
-	}
+	// assume that user will never add a nil object to config
+	initialTypes = append(initialTypes, config.Types...)
 
 	for _, ttype := range initialTypes {
 		if ttype.Error() != nil {
@@ -145,8 +145,8 @@ func NewSchema(config SchemaConfig) (Schema, error) {
 	return schema, nil
 }
 
-//Added Check implementation of interfaces at runtime..
-//Add Implementations at Runtime..
+// Added Check implementation of interfaces at runtime..
+// Add Implementations at Runtime..
 func (gq *Schema) AddImplementation() error {
 
 	// Keep track of all implementations by interface name.
@@ -181,8 +181,8 @@ func (gq *Schema) AddImplementation() error {
 	return nil
 }
 
-//Edited. To check add Types at RunTime..
-//Append Runtime schema to typeMap
+// Edited. To check add Types at RunTime..
+// Append Runtime schema to typeMap
 func (gq *Schema) AppendType(objectType Type) error {
 	if objectType.Error() != nil {
 		return objectType.Error()
@@ -246,8 +246,8 @@ func (gq *Schema) IsPossibleType(abstractType Abstract, possibleType *Object) bo
 		possibleTypeMap = map[string]map[string]bool{}
 	}
 
-	if typeMap, ok := possibleTypeMap[abstractType.Name()]; !ok {
-		typeMap = map[string]bool{}
+	if _, ok := possibleTypeMap[abstractType.Name()]; !ok {
+		typeMap := map[string]bool{}
 		for _, possibleType := range gq.PossibleTypes(abstractType) {
 			typeMap[possibleType.Name()] = true
 		}
@@ -256,7 +256,7 @@ func (gq *Schema) IsPossibleType(abstractType Abstract, possibleType *Object) bo
 
 	gq.possibleTypeMap = possibleTypeMap
 	if typeMap, ok := possibleTypeMap[abstractType.Name()]; ok {
-		isPossible, _ := typeMap[possibleType.Name()]
+		isPossible := typeMap[possibleType.Name()]
 		return isPossible
 	}
 	return false

--- a/subscription.go
+++ b/subscription.go
@@ -13,9 +13,9 @@ import (
 type SubscribeParams struct {
 	Schema        Schema
 	RequestString string
-	RootValue     interface{}
+	RootValue     any
 	// ContextValue    context.Context
-	VariableValues  map[string]interface{}
+	VariableValues  map[string]any
 	OperationName   string
 	FieldResolver   FieldResolveFn
 	FieldSubscriber FieldResolveFn
@@ -78,7 +78,7 @@ func ExecuteSubscription(p ExecuteParams) chan *Result {
 		p.Context = context.Background()
 	}
 
-	var mapSourceToResponse = func(payload interface{}) *Result {
+	var mapSourceToResponse = func(payload any) *Result {
 		return Execute(ExecuteParams{
 			Schema:        p.Schema,
 			Root:          payload,
@@ -203,8 +203,8 @@ func ExecuteSubscription(p ExecuteParams) chan *Result {
 		}
 
 		switch fieldResult.(type) {
-		case chan interface{}:
-			sub := fieldResult.(chan interface{})
+		case chan any:
+			sub := fieldResult.(chan any)
 			for {
 				select {
 				case <-p.Context.Done():

--- a/subscription.go
+++ b/subscription.go
@@ -101,7 +101,6 @@ func ExecuteSubscription(p ExecuteParams) chan *Result {
 					Errors: gqlerrors.FormatErrors(e),
 				}
 			}
-			return
 		}()
 
 		exeContext, err := buildExecutionContext(buildExecutionCtxParams{
@@ -202,15 +201,14 @@ func ExecuteSubscription(p ExecuteParams) chan *Result {
 			return
 		}
 
-		switch fieldResult.(type) {
+		switch v := fieldResult.(type) {
 		case chan any:
-			sub := fieldResult.(chan any)
 			for {
 				select {
 				case <-p.Context.Done():
 					return
 
-				case res, more := <-sub:
+				case res, more := <-v:
 					if !more {
 						return
 					}

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -19,7 +19,7 @@ func TestSchemaSubscribe(t *testing.T) {
 				Fields: graphql.Fields{
 					"sub_without_resolver": &graphql.Field{
 						Type: graphql.String,
-						Subscribe: makeSubscribeToMapFunction([]map[string]interface{}{
+						Subscribe: makeSubscribeToMapFunction([]map[string]any{
 							{
 								"sub_without_resolver": "a",
 							},
@@ -51,7 +51,7 @@ func TestSchemaSubscribe(t *testing.T) {
 				Fields: graphql.Fields{
 					"sub_with_resolver": &graphql.Field{
 						Type: graphql.String,
-						Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+						Resolve: func(p graphql.ResolveParams) (any, error) {
 							return p.Source, nil
 						},
 						Subscribe: makeSubscribeToStringFunction([]string{"a", "b", "c"}),
@@ -97,7 +97,7 @@ func TestSchemaSubscribe(t *testing.T) {
 				Fields: graphql.Fields{
 					"should_error": &graphql.Field{
 						Type: graphql.String,
-						Subscribe: func(p graphql.ResolveParams) (interface{}, error) {
+						Subscribe: func(p graphql.ResolveParams) (any, error) {
 							panic(errors.New("got a panic error"))
 						},
 					},
@@ -120,7 +120,7 @@ func TestSchemaSubscribe(t *testing.T) {
 					"sub_with_resolver": &graphql.Field{
 						Type:      graphql.String,
 						Subscribe: makeSubscribeToStringFunction([]string{"a", "b", "c", "d"}),
-						Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+						Resolve: func(p graphql.ResolveParams) (any, error) {
 							return fmt.Sprintf("result=%v", p.Source), nil
 						},
 					},
@@ -152,10 +152,10 @@ func TestSchemaSubscribe(t *testing.T) {
 								},
 							},
 						}),
-						Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+						Resolve: func(p graphql.ResolveParams) (any, error) {
 							return p.Source, nil
 						},
-						Subscribe: makeSubscribeToMapFunction([]map[string]interface{}{
+						Subscribe: makeSubscribeToMapFunction([]map[string]any{
 							{
 								"field": "hello",
 							},
@@ -190,7 +190,7 @@ func TestSchemaSubscribe(t *testing.T) {
 				Fields: graphql.Fields{
 					"should_error": &graphql.Field{
 						Type: graphql.String,
-						Subscribe: func(p graphql.ResolveParams) (interface{}, error) {
+						Subscribe: func(p graphql.ResolveParams) (any, error) {
 							return nil, errors.New("got a subscribe error")
 						},
 					},
@@ -231,9 +231,9 @@ func TestSchemaSubscribe(t *testing.T) {
 	})
 }
 
-func makeSubscribeToStringFunction(elements []string) func(p graphql.ResolveParams) (interface{}, error) {
-	return func(p graphql.ResolveParams) (interface{}, error) {
-		c := make(chan interface{})
+func makeSubscribeToStringFunction(elements []string) func(p graphql.ResolveParams) (any, error) {
+	return func(p graphql.ResolveParams) (any, error) {
+		c := make(chan any)
 		go func() {
 			for _, r := range elements {
 				select {
@@ -249,9 +249,9 @@ func makeSubscribeToStringFunction(elements []string) func(p graphql.ResolvePara
 	}
 }
 
-func makeSubscribeToMapFunction(elements []map[string]interface{}) func(p graphql.ResolveParams) (interface{}, error) {
-	return func(p graphql.ResolveParams) (interface{}, error) {
-		c := make(chan interface{})
+func makeSubscribeToMapFunction(elements []map[string]any) func(p graphql.ResolveParams) (any, error) {
+	return func(p graphql.ResolveParams) (any, error) {
+		c := make(chan any)
 		go func() {
 			for _, r := range elements {
 				select {

--- a/testutil/rules_test_harness.go
+++ b/testutil/rules_test_harness.go
@@ -557,7 +557,7 @@ func expectValidRule(t *testing.T, schema *graphql.Schema, rules []graphql.Valid
 	if len(result.Errors) > 0 {
 		t.Fatalf("Should validate, got %v", result.Errors)
 	}
-	if result.IsValid != true {
+	if !result.IsValid {
 		t.Fatalf("IsValid should be true, got %v", result.IsValid)
 	}
 
@@ -574,7 +574,7 @@ func expectInvalidRule(t *testing.T, schema *graphql.Schema, rules []graphql.Val
 	if len(result.Errors) != len(expectedErrors) {
 		t.Fatalf("Should have %v errors, got %v", len(expectedErrors), len(result.Errors))
 	}
-	if result.IsValid != false {
+	if result.IsValid {
 		t.Fatalf("IsValid should be false, got %v", result.IsValid)
 	}
 	for _, expectedErr := range expectedErrors {
@@ -585,7 +585,7 @@ func expectInvalidRule(t *testing.T, schema *graphql.Schema, rules []graphql.Val
 				break
 			}
 		}
-		if found == false {
+		if !found {
 			t.Fatalf("Unexpected result, Diff: %v", Diff(expectedErrors, result.Errors))
 		}
 	}

--- a/testutil/subscription.go
+++ b/testutil/subscription.go
@@ -23,7 +23,7 @@ type TestSubscription struct {
 	Schema          graphql.Schema
 	Query           string
 	OperationName   string
-	Variables       map[string]interface{}
+	Variables       map[string]any
 	ExpectedResults []TestResponse
 }
 
@@ -129,7 +129,7 @@ func checkErrorStrings(t *testing.T, expected, actual []string) {
 }
 
 func formatJSON(data string) ([]byte, error) {
-	var v interface{}
+	var v any
 	if err := json.Unmarshal([]byte(data), &v); err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func formatJSON(data string) ([]byte, error) {
 	return formatted, nil
 }
 
-func pretty(x interface{}) string {
+func pretty(x any) string {
 	got, err := json.MarshalIndent(x, "", "  ")
 	if err != nil {
 		panic(err)

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -245,7 +246,7 @@ func init() {
 								"id":   friend.ID,
 							})
 						}
-						return droid.Friends, nil
+						return friends, nil
 					}
 					return []any{}, nil
 				},
@@ -501,4 +502,17 @@ func EqualResults(expected, result *graphql.Result) bool {
 		return false
 	}
 	return EqualFormattedErrors(expected.Errors, result.Errors)
+}
+
+// testCtxKey is a type to avoid key collisions in context values.
+type testCtxKey string
+
+// ContextWithValue inserts value into the context.
+func ContextWithValue(ctx context.Context, k string, v any) context.Context {
+	return context.WithValue(ctx, testCtxKey(k), v)
+}
+
+// ContextValue retrieves a value from the context.
+func ContextValue(ctx context.Context, k string) any {
+	return ctx.Value(testCtxKey(k))
 }

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -239,14 +239,7 @@ func init() {
 				Description: "The friends of the droid, or an empty list if they have none.",
 				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if droid, ok := p.Source.(StarWarsChar); ok {
-						friends := []map[string]any{}
-						for _, friend := range droid.Friends {
-							friends = append(friends, map[string]any{
-								"name": friend.Name,
-								"id":   friend.ID,
-							})
-						}
-						return friends, nil
+						return droid.Friends, nil
 					}
 					return []any{}, nil
 				},
@@ -367,7 +360,7 @@ func TestExecute(t *testing.T, ep graphql.ExecuteParams) *graphql.Result {
 }
 
 func Diff(want, got any) []string {
-	return []string{fmt.Sprintf("\ngot: %v", got), fmt.Sprintf("\nwant: %v\n", want)}
+	return []string{fmt.Sprintf("\ngot:\n%v", got), fmt.Sprintf("\nwant:\n%v\n", want)}
 }
 
 func ASTToJSON(t *testing.T, a ast.Node) any {

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -157,7 +157,7 @@ func init() {
 			"id": &graphql.Field{
 				Type:        graphql.NewNonNull(graphql.String),
 				Description: "The id of the human.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.ID, nil
 					}
@@ -167,7 +167,7 @@ func init() {
 			"name": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The name of the human.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.Name, nil
 					}
@@ -177,17 +177,17 @@ func init() {
 			"friends": &graphql.Field{
 				Type:        graphql.NewList(characterInterface),
 				Description: "The friends of the human, or an empty list if they have none.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.Friends, nil
 					}
-					return []interface{}{}, nil
+					return []any{}, nil
 				},
 			},
 			"appearsIn": &graphql.Field{
 				Type:        graphql.NewList(episodeEnum),
 				Description: "Which movies they appear in.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.AppearsIn, nil
 					}
@@ -197,7 +197,7 @@ func init() {
 			"homePlanet": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The home planet of the human, or null if unknown.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.HomePlanet, nil
 					}
@@ -216,7 +216,7 @@ func init() {
 			"id": &graphql.Field{
 				Type:        graphql.NewNonNull(graphql.String),
 				Description: "The id of the droid.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						return droid.ID, nil
 					}
@@ -226,7 +226,7 @@ func init() {
 			"name": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The name of the droid.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						return droid.Name, nil
 					}
@@ -236,24 +236,24 @@ func init() {
 			"friends": &graphql.Field{
 				Type:        graphql.NewList(characterInterface),
 				Description: "The friends of the droid, or an empty list if they have none.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if droid, ok := p.Source.(StarWarsChar); ok {
-						friends := []map[string]interface{}{}
+						friends := []map[string]any{}
 						for _, friend := range droid.Friends {
-							friends = append(friends, map[string]interface{}{
+							friends = append(friends, map[string]any{
 								"name": friend.Name,
 								"id":   friend.ID,
 							})
 						}
 						return droid.Friends, nil
 					}
-					return []interface{}{}, nil
+					return []any{}, nil
 				},
 			},
 			"appearsIn": &graphql.Field{
 				Type:        graphql.NewList(episodeEnum),
 				Description: "Which movies they appear in.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						return droid.AppearsIn, nil
 					}
@@ -263,7 +263,7 @@ func init() {
 			"primaryFunction": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The primary function of the droid.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						return droid.PrimaryFunction, nil
 					}
@@ -288,7 +288,7 @@ func init() {
 						Type: episodeEnum,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					return GetHero(p.Args["episode"]), nil
 				},
 			},
@@ -300,7 +300,7 @@ func init() {
 						Type:        graphql.NewNonNull(graphql.String),
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					id, err := strconv.Atoi(p.Args["id"].(string))
 					if err != nil {
 						return nil, err
@@ -316,7 +316,7 @@ func init() {
 						Type:        graphql.NewNonNull(graphql.String),
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(p graphql.ResolveParams) (any, error) {
 					return GetDroid(p.Args["id"].(int)), nil
 				},
 			},
@@ -339,7 +339,7 @@ func GetDroid(id int) StarWarsChar {
 	}
 	return StarWarsChar{}
 }
-func GetHero(episode interface{}) interface{} {
+func GetHero(episode any) any {
 	if episode == 5 {
 		return Luke
 	}
@@ -365,16 +365,16 @@ func TestExecute(t *testing.T, ep graphql.ExecuteParams) *graphql.Result {
 	return graphql.Execute(ep)
 }
 
-func Diff(want, got interface{}) []string {
+func Diff(want, got any) []string {
 	return []string{fmt.Sprintf("\ngot: %v", got), fmt.Sprintf("\nwant: %v\n", want)}
 }
 
-func ASTToJSON(t *testing.T, a ast.Node) interface{} {
+func ASTToJSON(t *testing.T, a ast.Node) any {
 	b, err := json.Marshal(a)
 	if err != nil {
 		t.Fatalf("Failed to marshal Node %v", err)
 	}
-	var f interface{}
+	var f any
 	err = json.Unmarshal(b, &f)
 	if err != nil {
 		t.Fatalf("Failed to unmarshal Node %v", err)
@@ -382,7 +382,7 @@ func ASTToJSON(t *testing.T, a ast.Node) interface{} {
 	return f
 }
 
-func ContainSubsetSlice(super []interface{}, sub []interface{}) bool {
+func ContainSubsetSlice(super []any, sub []any) bool {
 	if len(sub) == 0 {
 		return true
 	}
@@ -391,8 +391,8 @@ subLoop:
 		found := false
 	innerLoop:
 		for _, superVal := range super {
-			if subVal, ok := subVal.(map[string]interface{}); ok {
-				if superVal, ok := superVal.(map[string]interface{}); ok {
+			if subVal, ok := subVal.(map[string]any); ok {
+				if superVal, ok := superVal.(map[string]any); ok {
 					if ContainSubset(superVal, subVal) {
 						found = true
 						break innerLoop
@@ -404,8 +404,8 @@ subLoop:
 				}
 
 			}
-			if subVal, ok := subVal.([]interface{}); ok {
-				if superVal, ok := superVal.([]interface{}); ok {
+			if subVal, ok := subVal.([]any); ok {
+				if superVal, ok := superVal.([]any); ok {
 					if ContainSubsetSlice(superVal, subVal) {
 						found = true
 						break innerLoop
@@ -429,23 +429,23 @@ subLoop:
 	return true
 }
 
-func ContainSubset(super map[string]interface{}, sub map[string]interface{}) bool {
+func ContainSubset(super map[string]any, sub map[string]any) bool {
 	if len(sub) == 0 {
 		return true
 	}
 	for subKey, subVal := range sub {
 		if superVal, ok := super[subKey]; ok {
 			switch superVal := superVal.(type) {
-			case []interface{}:
-				if subVal, ok := subVal.([]interface{}); ok {
+			case []any:
+				if subVal, ok := subVal.([]any); ok {
 					if !ContainSubsetSlice(superVal, subVal) {
 						return false
 					}
 				} else {
 					return false
 				}
-			case map[string]interface{}:
-				if subVal, ok := subVal.(map[string]interface{}); ok {
+			case map[string]any:
+				if subVal, ok := subVal.(map[string]any); ok {
 					if !ContainSubset(superVal, subVal) {
 						return false
 					}

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -8,10 +8,10 @@ import (
 
 func TestSubsetSlice_Simple(t *testing.T) {
 
-	super := []interface{}{
+	super := []any{
 		"1", "2", "3",
 	}
-	sub := []interface{}{
+	sub := []any{
 		"3",
 	}
 	if !testutil.ContainSubsetSlice(super, sub) {
@@ -20,10 +20,10 @@ func TestSubsetSlice_Simple(t *testing.T) {
 }
 func TestSubsetSlice_Simple_Fail(t *testing.T) {
 
-	super := []interface{}{
+	super := []any{
 		"1", "2", "3",
 	}
-	sub := []interface{}{
+	sub := []any{
 		"4",
 	}
 	if testutil.ContainSubsetSlice(super, sub) {
@@ -32,25 +32,25 @@ func TestSubsetSlice_Simple_Fail(t *testing.T) {
 }
 func TestSubsetSlice_NestedSlice(t *testing.T) {
 
-	super := []interface{}{
-		[]interface{}{
+	super := []any{
+		[]any{
 			"1", "2", "3",
 		},
-		[]interface{}{
+		[]any{
 			"4", "5", "6",
 		},
-		[]interface{}{
+		[]any{
 			"7", "8", "9",
 		},
 	}
-	sub := []interface{}{
-		[]interface{}{
+	sub := []any{
+		[]any{
 			"2",
 		},
-		[]interface{}{
+		[]any{
 			"9",
 		},
-		[]interface{}{
+		[]any{
 			"5",
 		},
 	}
@@ -60,22 +60,22 @@ func TestSubsetSlice_NestedSlice(t *testing.T) {
 }
 func TestSubsetSlice_NestedSlice_DifferentLength(t *testing.T) {
 
-	super := []interface{}{
-		[]interface{}{
+	super := []any{
+		[]any{
 			"1", "2", "3",
 		},
-		[]interface{}{
+		[]any{
 			"4", "5", "6",
 		},
-		[]interface{}{
+		[]any{
 			"7", "8", "9",
 		},
 	}
-	sub := []interface{}{
-		[]interface{}{
+	sub := []any{
+		[]any{
 			"3",
 		},
-		[]interface{}{
+		[]any{
 			"6",
 		},
 	}
@@ -85,25 +85,25 @@ func TestSubsetSlice_NestedSlice_DifferentLength(t *testing.T) {
 }
 func TestSubsetSlice_NestedSlice_Fail(t *testing.T) {
 
-	super := []interface{}{
-		[]interface{}{
+	super := []any{
+		[]any{
 			"1", "2", "3",
 		},
-		[]interface{}{
+		[]any{
 			"4", "5", "6",
 		},
-		[]interface{}{
+		[]any{
 			"7", "8", "9",
 		},
 	}
-	sub := []interface{}{
-		[]interface{}{
+	sub := []any{
+		[]any{
 			"3",
 		},
-		[]interface{}{
+		[]any{
 			"3",
 		},
-		[]interface{}{
+		[]any{
 			"9",
 		},
 	}
@@ -114,12 +114,12 @@ func TestSubsetSlice_NestedSlice_Fail(t *testing.T) {
 
 func TestSubset_Simple(t *testing.T) {
 
-	super := map[string]interface{}{
+	super := map[string]any{
 		"a": "1",
 		"b": "2",
 		"c": "3",
 	}
-	sub := map[string]interface{}{
+	sub := map[string]any{
 		"c": "3",
 	}
 	if !testutil.ContainSubset(super, sub) {
@@ -129,12 +129,12 @@ func TestSubset_Simple(t *testing.T) {
 }
 func TestSubset_Simple_Fail(t *testing.T) {
 
-	super := map[string]interface{}{
+	super := map[string]any{
 		"a": "1",
 		"b": "2",
 		"c": "3",
 	}
-	sub := map[string]interface{}{
+	sub := map[string]any{
 		"d": "3",
 	}
 	if testutil.ContainSubset(super, sub) {
@@ -144,19 +144,19 @@ func TestSubset_Simple_Fail(t *testing.T) {
 }
 func TestSubset_NestedMap(t *testing.T) {
 
-	super := map[string]interface{}{
+	super := map[string]any{
 		"a": "1",
 		"b": "2",
 		"c": "3",
-		"d": map[string]interface{}{
+		"d": map[string]any{
 			"aa": "11",
 			"bb": "22",
 			"cc": "33",
 		},
 	}
-	sub := map[string]interface{}{
+	sub := map[string]any{
 		"c": "3",
-		"d": map[string]interface{}{
+		"d": map[string]any{
 			"cc": "33",
 		},
 	}
@@ -166,19 +166,19 @@ func TestSubset_NestedMap(t *testing.T) {
 }
 func TestSubset_NestedMap_Fail(t *testing.T) {
 
-	super := map[string]interface{}{
+	super := map[string]any{
 		"a": "1",
 		"b": "2",
 		"c": "3",
-		"d": map[string]interface{}{
+		"d": map[string]any{
 			"aa": "11",
 			"bb": "22",
 			"cc": "33",
 		},
 	}
-	sub := map[string]interface{}{
+	sub := map[string]any{
 		"c": "3",
-		"d": map[string]interface{}{
+		"d": map[string]any{
 			"dd": "44",
 		},
 	}
@@ -188,17 +188,17 @@ func TestSubset_NestedMap_Fail(t *testing.T) {
 }
 func TestSubset_NestedSlice(t *testing.T) {
 
-	super := map[string]interface{}{
+	super := map[string]any{
 		"a": "1",
 		"b": "2",
 		"c": "3",
-		"d": []interface{}{
+		"d": []any{
 			"11", "22",
 		},
 	}
-	sub := map[string]interface{}{
+	sub := map[string]any{
 		"c": "3",
-		"d": []interface{}{
+		"d": []any{
 			"11",
 		},
 	}
@@ -208,45 +208,45 @@ func TestSubset_NestedSlice(t *testing.T) {
 }
 func TestSubset_ComplexMixed(t *testing.T) {
 
-	super := map[string]interface{}{
+	super := map[string]any{
 		"a": "1",
 		"b": "2",
 		"c": "3",
-		"d": map[string]interface{}{
+		"d": map[string]any{
 			"aa": "11",
 			"bb": "22",
-			"cc": []interface{}{
+			"cc": []any{
 				"ttt", "rrr", "sss",
 			},
 		},
-		"e": []interface{}{
+		"e": []any{
 			"111", "222", "333",
 		},
-		"f": []interface{}{
-			[]interface{}{
+		"f": []any{
+			[]any{
 				"9999", "8888", "7777",
 			},
-			[]interface{}{
+			[]any{
 				"6666", "5555", "4444",
 			},
 		},
 	}
-	sub := map[string]interface{}{
+	sub := map[string]any{
 		"c": "3",
-		"d": map[string]interface{}{
+		"d": map[string]any{
 			"bb": "22",
-			"cc": []interface{}{
+			"cc": []any{
 				"sss",
 			},
 		},
-		"e": []interface{}{
+		"e": []any{
 			"111",
 		},
-		"f": []interface{}{
-			[]interface{}{
+		"f": []any{
+			[]any{
 				"8888", "9999",
 			},
-			[]interface{}{
+			[]any{
 				"4444",
 			},
 		},
@@ -257,42 +257,42 @@ func TestSubset_ComplexMixed(t *testing.T) {
 }
 func TestSubset_ComplexMixed_Fail(t *testing.T) {
 
-	super := map[string]interface{}{
+	super := map[string]any{
 		"a": "1",
 		"b": "2",
 		"c": "3",
-		"d": map[string]interface{}{
+		"d": map[string]any{
 			"aa": "11",
 			"bb": "22",
-			"cc": []interface{}{
+			"cc": []any{
 				"ttt", "rrr", "sss",
 			},
 		},
-		"e": []interface{}{
+		"e": []any{
 			"111", "222", "333",
 		},
-		"f": []interface{}{
-			[]interface{}{
+		"f": []any{
+			[]any{
 				"9999", "8888", "7777",
 			},
-			[]interface{}{
+			[]any{
 				"6666", "5555", "4444",
 			},
 		},
 	}
-	sub := map[string]interface{}{
+	sub := map[string]any{
 		"c": "3",
-		"d": map[string]interface{}{
+		"d": map[string]any{
 			"bb": "22",
-			"cc": []interface{}{
+			"cc": []any{
 				"doesnotexist",
 			},
 		},
-		"e": []interface{}{
+		"e": []any{
 			"111",
 		},
-		"f": []interface{}{
-			[]interface{}{
+		"f": []any{
+			[]any{
 				"4444",
 			},
 		},

--- a/type_info.go
+++ b/type_info.go
@@ -259,11 +259,11 @@ func DefaultTypeInfoFieldDef(schema *Schema, parentType Type, fieldAST *ast.Fiel
 	}
 
 	if parentType, ok := parentType.(*Object); ok && parentType != nil {
-		field, _ := parentType.Fields()[name]
+		field := parentType.Fields()[name]
 		return field
 	}
 	if parentType, ok := parentType.(*Interface); ok && parentType != nil {
-		field, _ := parentType.Fields()[name]
+		field := parentType.Fields()[name]
 		return field
 	}
 	return nil

--- a/types.go
+++ b/types.go
@@ -4,13 +4,13 @@ import (
 	"github.com/machship/graphql/gqlerrors"
 )
 
-// type Schema interface{}
+// type Schema any
 
 // Result has the response, errors and extensions from the resolved schema
 type Result struct {
-	Data       interface{}                `json:"data"`
+	Data       any                        `json:"data"`
 	Errors     []gqlerrors.FormattedError `json:"errors,omitempty"`
-	Extensions map[string]interface{}     `json:"extensions,omitempty"`
+	Extensions map[string]any             `json:"extensions,omitempty"`
 }
 
 // HasErrors just a simple function to help you decide if the result has errors or not

--- a/union_interface_test.go
+++ b/union_interface_test.go
@@ -154,40 +154,40 @@ func TestUnionIntersectionTypes_CanIntrospectOnUnionAndIntersectionTypes(t *test
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"Named": map[string]interface{}{
+		Data: map[string]any{
+			"Named": map[string]any{
 				"kind": "INTERFACE",
 				"name": "Named",
-				"fields": []interface{}{
-					map[string]interface{}{
+				"fields": []any{
+					map[string]any{
 						"name": "name",
 					},
 				},
 				"interfaces": nil,
-				"possibleTypes": []interface{}{
-					map[string]interface{}{
+				"possibleTypes": []any{
+					map[string]any{
 						"name": "Dog",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name": "Cat",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name": "Person",
 					},
 				},
 				"enumValues":  nil,
 				"inputFields": nil,
 			},
-			"Pet": map[string]interface{}{
+			"Pet": map[string]any{
 				"kind":       "UNION",
 				"name":       "Pet",
 				"fields":     nil,
 				"interfaces": nil,
-				"possibleTypes": []interface{}{
-					map[string]interface{}{
+				"possibleTypes": []any{
+					map[string]any{
 						"name": "Dog",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name": "Cat",
 					},
 				},
@@ -208,7 +208,7 @@ func TestUnionIntersectionTypes_CanIntrospectOnUnionAndIntersectionTypes(t *test
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
-	if !testutil.ContainSubset(expected.Data.(map[string]interface{}), result.Data.(map[string]interface{})) {
+	if !testutil.ContainSubset(expected.Data.(map[string]any), result.Data.(map[string]any)) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Data, result.Data))
 	}
 }
@@ -227,16 +227,16 @@ func TestUnionIntersectionTypes_ExecutesUsingUnionTypes(t *testing.T) {
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"__typename": "Person",
 			"name":       "John",
-			"pets": []interface{}{
-				map[string]interface{}{
+			"pets": []any{
+				map[string]any{
 					"__typename": "Cat",
 					"name":       "Garfield",
 					"meows":      false,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"__typename": "Dog",
 					"name":       "Odie",
 					"barks":      true,
@@ -281,16 +281,16 @@ func TestUnionIntersectionTypes_ExecutesUnionTypesWithInlineFragments(t *testing
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"__typename": "Person",
 			"name":       "John",
-			"pets": []interface{}{
-				map[string]interface{}{
+			"pets": []any{
+				map[string]any{
 					"__typename": "Cat",
 					"name":       "Garfield",
 					"meows":      false,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"__typename": "Dog",
 					"name":       "Odie",
 					"barks":      true,
@@ -331,15 +331,15 @@ func TestUnionIntersectionTypes_ExecutesUsingInterfaceTypes(t *testing.T) {
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"__typename": "Person",
 			"name":       "John",
-			"friends": []interface{}{
-				map[string]interface{}{
+			"friends": []any{
+				map[string]any{
 					"__typename": "Person",
 					"name":       "Liz",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"__typename": "Dog",
 					"name":       "Odie",
 					"barks":      true,
@@ -384,15 +384,15 @@ func TestUnionIntersectionTypes_ExecutesInterfaceTypesWithInlineFragments(t *tes
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"__typename": "Person",
 			"name":       "John",
-			"friends": []interface{}{
-				map[string]interface{}{
+			"friends": []any{
+				map[string]any{
 					"__typename": "Person",
 					"name":       "Liz",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"__typename": "Dog",
 					"name":       "Odie",
 					"barks":      true,
@@ -452,27 +452,27 @@ func TestUnionIntersectionTypes_AllowsFragmentConditionsToBeAbstractTypes(t *tes
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"__typename": "Person",
 			"name":       "John",
-			"friends": []interface{}{
-				map[string]interface{}{
+			"friends": []any{
+				map[string]any{
 					"__typename": "Person",
 					"name":       "Liz",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"__typename": "Dog",
 					"name":       "Odie",
 					"barks":      true,
 				},
 			},
-			"pets": []interface{}{
-				map[string]interface{}{
+			"pets": []any{
+				map[string]any{
 					"__typename": "Cat",
 					"name":       "Garfield",
 					"meows":      false,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"__typename": "Dog",
 					"name":       "Odie",
 					"barks":      true,
@@ -547,10 +547,10 @@ func TestUnionIntersectionTypes_GetsExecutionInfoInResolver(t *testing.T) {
 
 	doc := `{ name, friends { name } }`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"name": "John",
-			"friends": []interface{}{
-				map[string]interface{}{
+			"friends": []any{
+				map[string]any{
 					"name": "Liz",
 				},
 			},
@@ -603,7 +603,7 @@ func TestUnionIntersectionTypes_ValueMayBeNilPointer(t *testing.T) {
 							},
 						},
 					}),
-					Resolve: func(_ graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(_ graphql.ResolveParams) (any, error) {
 						return struct {
 							Pet   *testCat2 `graphql:"pet"`
 							Named *testCat2 `graphql:"named"`
@@ -625,8 +625,8 @@ func TestUnionIntersectionTypes_ValueMayBeNilPointer(t *testing.T) {
 		}
 	}`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"query": map[string]interface{}{
+		Data: map[string]any{
+			"query": map[string]any{
 				"pet":   nil,
 				"named": nil,
 			}},

--- a/union_interface_test.go
+++ b/union_interface_test.go
@@ -513,7 +513,6 @@ func TestUnionIntersectionTypes_GetsExecutionInfoInResolver(t *testing.T) {
 		},
 		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
 			encounteredSchema = p.Info.Schema
-			encounteredContextValue, _ = p.Context.Value("authToken").(string)
 			encounteredContextValue = testutil.ContextValue(p.Context, "authToken").(string)
 			encounteredRootValue = p.Info.RootValue.(*testPerson).Name
 			return personType2
@@ -535,9 +534,12 @@ func TestUnionIntersectionTypes_GetsExecutionInfoInResolver(t *testing.T) {
 		},
 	})
 
-	schema2, _ := graphql.NewSchema(graphql.SchemaConfig{
+	schema2, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: personType2,
 	})
+	if err != nil {
+		t.Fatalf("Unexepected error %s", err)
+	}
 
 	john2 := &testPerson{
 		Name: "John",

--- a/union_interface_test.go
+++ b/union_interface_test.go
@@ -257,7 +257,7 @@ func TestUnionIntersectionTypes_ExecutesUsingUnionTypes(t *testing.T) {
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -311,7 +311,7 @@ func TestUnionIntersectionTypes_ExecutesUnionTypesWithInlineFragments(t *testing
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -360,7 +360,7 @@ func TestUnionIntersectionTypes_ExecutesUsingInterfaceTypes(t *testing.T) {
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -413,7 +413,7 @@ func TestUnionIntersectionTypes_ExecutesInterfaceTypesWithInlineFragments(t *tes
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -493,7 +493,7 @@ func TestUnionIntersectionTypes_AllowsFragmentConditionsToBeAbstractTypes(t *tes
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -572,7 +572,7 @@ func TestUnionIntersectionTypes_GetsExecutionInfoInResolver(t *testing.T) {
 	}
 	result := testutil.TestExecute(t, ep)
 
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 	if !reflect.DeepEqual("contextStringValue123", encounteredContextValue) {
@@ -635,7 +635,7 @@ func TestUnionIntersectionTypes_ValueMayBeNilPointer(t *testing.T) {
 		Schema:        unionInterfaceTestSchema,
 		RequestString: query,
 	})
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }

--- a/union_interface_test.go
+++ b/union_interface_test.go
@@ -560,8 +560,7 @@ func TestUnionIntersectionTypes_GetsExecutionInfoInResolver(t *testing.T) {
 	ast := testutil.TestParse(t, doc)
 
 	// create context
-	ctx := context.Background()
-	ctx = context.WithValue(ctx, "authToken", "contextStringValue123")
+	ctx := testutil.ContextWithValue(context.Background(), "authToken", "contextStringValue123")
 
 	// execute
 	ep := graphql.ExecuteParams{

--- a/union_interface_test.go
+++ b/union_interface_test.go
@@ -514,6 +514,7 @@ func TestUnionIntersectionTypes_GetsExecutionInfoInResolver(t *testing.T) {
 		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
 			encounteredSchema = p.Info.Schema
 			encounteredContextValue, _ = p.Context.Value("authToken").(string)
+			encounteredContextValue = testutil.ContextValue(p.Context, "authToken").(string)
 			encounteredRootValue = p.Info.RootValue.(*testPerson).Name
 			return personType2
 		},

--- a/util.go
+++ b/util.go
@@ -11,11 +11,13 @@ const TAG = "json"
 
 // can't take recursive slice type
 // e.g
-// type Person struct{
-//	Friends []Person
-// }
+//
+//	type Person struct{
+//		Friends []Person
+//	}
+//
 // it will throw panic stack-overflow
-func BindFields(obj interface{}) Fields {
+func BindFields(obj any) Fields {
 	t := reflect.TypeOf(obj)
 	v := reflect.ValueOf(obj)
 	fields := make(map[string]*Field)
@@ -70,7 +72,7 @@ func BindFields(obj interface{}) Fields {
 		}
 		fields[tag] = &Field{
 			Type: graphType,
-			Resolve: func(p ResolveParams) (interface{}, error) {
+			Resolve: func(p ResolveParams) (any, error) {
 				return extractValue(tag, p.Source), nil
 			},
 		}
@@ -125,7 +127,7 @@ func appendFields(dest, origin Fields) Fields {
 	return dest
 }
 
-func extractValue(originTag string, obj interface{}) interface{} {
+func extractValue(originTag string, obj any) any {
 	val := reflect.Indirect(reflect.ValueOf(obj))
 
 	for j := 0; j < val.NumField(); j++ {
@@ -161,7 +163,7 @@ func extractTag(tag reflect.StructTag) string {
 }
 
 // lazy way of binding args
-func BindArg(obj interface{}, tags ...string) FieldConfigArgument {
+func BindArg(obj any, tags ...string) FieldConfigArgument {
 	v := reflect.Indirect(reflect.ValueOf(obj))
 	var config = make(FieldConfigArgument)
 	for i := 0; i < v.NumField(); i++ {
@@ -177,7 +179,7 @@ func BindArg(obj interface{}, tags ...string) FieldConfigArgument {
 	return config
 }
 
-func inArray(slice interface{}, item interface{}) bool {
+func inArray(slice any, item any) bool {
 	s := reflect.ValueOf(slice)
 	if s.Kind() != reflect.Slice {
 		panic("inArray() given a non-slice type")

--- a/util_test.go
+++ b/util_test.go
@@ -68,7 +68,7 @@ func TestBindFields(t *testing.T) {
 	fields := graphql.Fields{
 		"person": &graphql.Field{
 			Type: personType,
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(p graphql.ResolveParams) (any, error) {
 				return personSource, nil
 			},
 		},
@@ -129,7 +129,7 @@ func TestBindArg(t *testing.T) {
 			Type: friendObj,
 			//it can be added more than one since it's a slice
 			Args: graphql.BindArg(Friend{}, "name"),
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(p graphql.ResolveParams) (any, error) {
 				if name, ok := p.Args["name"].(string); ok {
 					for _, friend := range friendSource {
 						if friend.Name == name {

--- a/validation_test.go
+++ b/validation_test.go
@@ -9,13 +9,13 @@ import (
 
 var someScalarType = graphql.NewScalar(graphql.ScalarConfig{
 	Name: "SomeScalar",
-	Serialize: func(value interface{}) interface{} {
+	Serialize: func(value any) any {
 		return nil
 	},
-	ParseValue: func(value interface{}) interface{} {
+	ParseValue: func(value any) any {
 		return nil
 	},
-	ParseLiteral: func(valueAST ast.Value) interface{} {
+	ParseLiteral: func(valueAST ast.Value) any {
 		return nil
 	},
 })
@@ -325,7 +325,7 @@ func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichRedef
 
 	fakeString := graphql.NewScalar(graphql.ScalarConfig{
 		Name: "String",
-		Serialize: func(value interface{}) interface{} {
+		Serialize: func(value any) any {
 			return nil
 		},
 	})
@@ -843,7 +843,7 @@ func TestTypeSystem_ScalarTypesMustBeSerializable_AcceptsAScalarTypeDefiningSeri
 
 	_, err := schemaWithFieldType(graphql.NewScalar(graphql.ScalarConfig{
 		Name: "SomeScalar",
-		Serialize: func(value interface{}) interface{} {
+		Serialize: func(value any) any {
 			return nil
 		},
 	}))
@@ -867,13 +867,13 @@ func TestTypeSystem_ScalarTypesMustBeSerializable_AcceptsAScalarTypeDefiningPars
 
 	_, err := schemaWithFieldType(graphql.NewScalar(graphql.ScalarConfig{
 		Name: "SomeScalar",
-		Serialize: func(value interface{}) interface{} {
+		Serialize: func(value any) any {
 			return nil
 		},
-		ParseValue: func(value interface{}) interface{} {
+		ParseValue: func(value any) any {
 			return nil
 		},
-		ParseLiteral: func(valueAST ast.Value) interface{} {
+		ParseLiteral: func(valueAST ast.Value) any {
 			return nil
 		},
 	}))
@@ -885,10 +885,10 @@ func TestTypeSystem_ScalarTypesMustBeSerializable_RejectsAScalarTypeDefiningPars
 
 	_, err := schemaWithFieldType(graphql.NewScalar(graphql.ScalarConfig{
 		Name: "SomeScalar",
-		Serialize: func(value interface{}) interface{} {
+		Serialize: func(value any) any {
 			return nil
 		},
-		ParseValue: func(value interface{}) interface{} {
+		ParseValue: func(value any) any {
 			return nil
 		},
 	}))
@@ -901,10 +901,10 @@ func TestTypeSystem_ScalarTypesMustBeSerializable_RejectsAScalarTypeDefiningPars
 
 	_, err := schemaWithFieldType(graphql.NewScalar(graphql.ScalarConfig{
 		Name: "SomeScalar",
-		Serialize: func(value interface{}) interface{} {
+		Serialize: func(value any) any {
 			return nil
 		},
-		ParseLiteral: func(valueAST ast.Value) interface{} {
+		ParseLiteral: func(valueAST ast.Value) any {
 			return nil
 		},
 	}))

--- a/validator.go
+++ b/validator.go
@@ -231,12 +231,12 @@ func (ctx *ValidationContext) VariableUsages(node HasSelectionSet) []*VariableUs
 	visitor.Visit(node, visitor.VisitWithTypeInfo(typeInfo, &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
 			kinds.VariableDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					return visitor.ActionSkip, nil
 				},
 			},
 			kinds.Variable: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+				Kind: func(p visitor.VisitFuncParams) (string, any) {
 					if node, ok := p.Node.(*ast.Variable); ok && node != nil {
 						usages = append(usages, &VariableUsage{
 							Node: node,

--- a/validator.go
+++ b/validator.go
@@ -142,7 +142,7 @@ func (ctx *ValidationContext) Fragment(name string) *ast.FragmentDefinition {
 		}
 		ctx.fragments = fragments
 	}
-	f, _ := ctx.fragments[name]
+	f := ctx.fragments[name]
 	return f
 }
 func (ctx *ValidationContext) FragmentSpreads(node *ast.SelectionSet) []*ast.FragmentSpread {

--- a/values.go
+++ b/values.go
@@ -275,10 +275,8 @@ func isValidInputValue(value any, ttype Input) (bool, []string) {
 		// Ensure every defined field is valid.
 		for _, fieldName := range fieldNames {
 			_, messages := isValidInputValue(valueMap[fieldName], fields[fieldName].Type)
-			if messages != nil {
-				for _, message := range messages {
-					messagesReduce = append(messagesReduce, fmt.Sprintf(`In field "%v": %v`, fieldName, message))
-				}
+			for _, message := range messages {
+				messagesReduce = append(messagesReduce, fmt.Sprintf(`In field "%v": %v`, fieldName, message))
 			}
 		}
 		return (len(messagesReduce) == 0), messagesReduce
@@ -314,9 +312,10 @@ func isNullish(src any) bool {
 			return true
 		}
 	case reflect.Int:
-		return math.IsNaN(float64(value.Int()))
+		return false
+
 	case reflect.Float32, reflect.Float64:
-		return math.IsNaN(float64(value.Float()))
+		return math.IsNaN(value.Float())
 	}
 	return false
 }

--- a/values.go
+++ b/values.go
@@ -20,8 +20,8 @@ import (
 func getVariableValues(
 	schema Schema,
 	definitionASTs []*ast.VariableDefinition,
-	inputs map[string]interface{}) (map[string]interface{}, error) {
-	values := map[string]interface{}{}
+	inputs map[string]any) (map[string]any, error) {
+	values := map[string]any{}
 	for _, defAST := range definitionASTs {
 		if defAST == nil || defAST.Variable == nil || defAST.Variable.Name == nil {
 			continue
@@ -40,7 +40,7 @@ func getVariableValues(
 // definitions and list of argument AST nodes.
 func getArgumentValues(
 	argDefs []*Argument, argASTs []*ast.Argument,
-	variableValues map[string]interface{}) map[string]interface{} {
+	variableValues map[string]any) map[string]any {
 
 	argASTMap := map[string]*ast.Argument{}
 	for _, argAST := range argASTs {
@@ -48,10 +48,10 @@ func getArgumentValues(
 			argASTMap[argAST.Name.Value] = argAST
 		}
 	}
-	results := map[string]interface{}{}
+	results := map[string]any{}
 	for _, argDef := range argDefs {
 		var (
-			tmp   interface{}
+			tmp   any
 			value ast.Value
 		)
 		if tmpValue, ok := argASTMap[argDef.PrivateName]; ok {
@@ -69,7 +69,7 @@ func getArgumentValues(
 
 // Given a variable definition, and any value of input, return a value which
 // adheres to the variable definition, or throw an error.
-func getVariableValue(schema Schema, definitionAST *ast.VariableDefinition, input interface{}) (interface{}, error) {
+func getVariableValue(schema Schema, definitionAST *ast.VariableDefinition, input any) (any, error) {
 	ttype, err := typeFromAST(schema, definitionAST.Type)
 	if err != nil {
 		return nil, err
@@ -130,7 +130,7 @@ func getVariableValue(schema Schema, definitionAST *ast.VariableDefinition, inpu
 }
 
 // Given a type and any value, return a runtime value coerced to match the type.
-func coerceValue(ttype Input, value interface{}) interface{} {
+func coerceValue(ttype Input, value any) any {
 	if isNullish(value) {
 		return nil
 	}
@@ -138,7 +138,7 @@ func coerceValue(ttype Input, value interface{}) interface{} {
 	case *NonNull:
 		return coerceValue(ttype.OfType, value)
 	case *List:
-		var values = []interface{}{}
+		var values = []any{}
 		valType := reflect.ValueOf(value)
 		if valType.Kind() == reflect.Slice {
 			for i := 0; i < valType.Len(); i++ {
@@ -149,10 +149,10 @@ func coerceValue(ttype Input, value interface{}) interface{} {
 		}
 		return append(values, coerceValue(ttype.OfType, value))
 	case *InputObject:
-		var obj = map[string]interface{}{}
-		valueMap, _ := value.(map[string]interface{})
+		var obj = map[string]any{}
+		valueMap, _ := value.(map[string]any)
 		if valueMap == nil {
-			valueMap = map[string]interface{}{}
+			valueMap = map[string]any{}
 		}
 
 		for name, field := range ttype.Fields() {
@@ -211,7 +211,7 @@ func typeFromAST(schema Schema, inputTypeAST ast.Type) (Type, error) {
 // Given a value and a GraphQL type, determine if the value will be
 // accepted for that type. This is primarily useful for validating the
 // runtime values of query variables.
-func isValidInputValue(value interface{}, ttype Input) (bool, []string) {
+func isValidInputValue(value any, ttype Input) (bool, []string) {
 	if isNullish(value) {
 		if ttype, ok := ttype.(*NonNull); ok {
 			if ttype.OfType.Name() != "" {
@@ -245,7 +245,7 @@ func isValidInputValue(value interface{}, ttype Input) (bool, []string) {
 	case *InputObject:
 		messagesReduce := []string{}
 
-		valueMap, ok := value.(map[string]interface{})
+		valueMap, ok := value.(map[string]any)
 		if !ok {
 			return false, []string{fmt.Sprintf(`Expected "%v", found not an object.`, ttype.Name())}
 		}
@@ -296,7 +296,7 @@ func isValidInputValue(value interface{}, ttype Input) (bool, []string) {
 }
 
 // Returns true if a value is null, undefined, or NaN.
-func isNullish(src interface{}) bool {
+func isNullish(src any) bool {
 	if src == nil {
 		return true
 	}
@@ -322,7 +322,7 @@ func isNullish(src interface{}) bool {
 }
 
 // Returns true if src is a slice or an array
-func isIterable(src interface{}) bool {
+func isIterable(src any) bool {
 	if src == nil {
 		return false
 	}
@@ -348,7 +348,7 @@ func isIterable(src interface{}) bool {
  * | Int / Float          | Number        |
  *
  */
-func valueFromAST(valueAST ast.Value, ttype Input, variables map[string]interface{}) interface{} {
+func valueFromAST(valueAST ast.Value, ttype Input, variables map[string]any) any {
 	if valueAST == nil {
 		return nil
 	}
@@ -366,7 +366,7 @@ func valueFromAST(valueAST ast.Value, ttype Input, variables map[string]interfac
 	case *NonNull:
 		return valueFromAST(valueAST, ttype.OfType, variables)
 	case *List:
-		values := []interface{}{}
+		values := []any{}
 		if valueAST, ok := valueAST.(*ast.ListValue); ok {
 			for _, itemAST := range valueAST.Values {
 				values = append(values, valueFromAST(itemAST, ttype.OfType, variables))
@@ -390,9 +390,9 @@ func valueFromAST(valueAST ast.Value, ttype Input, variables map[string]interfac
 			}
 			fieldASTs[of.Name.Value] = of
 		}
-		obj := map[string]interface{}{}
+		obj := map[string]any{}
 		for name, field := range ttype.Fields() {
-			var value interface{}
+			var value any
 			if of, ok = fieldASTs[name]; ok {
 				value = valueFromAST(of.Value, field.Type, variables)
 			} else {
@@ -419,7 +419,7 @@ func invariant(condition bool, message string) error {
 	return nil
 }
 
-func invariantf(condition bool, format string, a ...interface{}) error {
+func invariantf(condition bool, format string, a ...any) error {
 	if !condition {
 		return gqlerrors.NewFormattedError(fmt.Sprintf(format, a...))
 	}

--- a/variables_test.go
+++ b/variables_test.go
@@ -193,7 +193,7 @@ func TestVariables_ObjectsAndNullability_UsingInlineStructs_ExecutesWithComplexI
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -220,7 +220,7 @@ func TestVariables_ObjectsAndNullability_UsingInlineStructs_ProperlyParsesSingle
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -247,7 +247,7 @@ func TestVariables_ObjectsAndNullability_UsingInlineStructs_DoesNotUseIncorrectV
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -274,7 +274,7 @@ func TestVariables_ObjectsAndNullability_UsingInlineStructs_ProperlyRunsParseLit
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -314,7 +314,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ExecutesWithComplexInput
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -343,7 +343,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_UsesDefaultValueWhenNotP
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -373,7 +373,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ProperlyParsesSingleValu
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -402,7 +402,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ExecutesWithComplexScala
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -611,7 +611,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeOmitted(t *testing.T)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -638,7 +638,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeOmittedInAVariable(t 
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -665,7 +665,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeOmittedInAnUnlistedVa
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -696,7 +696,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeSetToNullInAVariable(
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -727,7 +727,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeSetToAValueInAVariabl
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -754,7 +754,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeSetToAValueDirectly(t
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -858,7 +858,7 @@ func TestVariables_NonNullableScalars_AllowsNonNullableInputsToBeSetToAValueInAV
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -891,7 +891,7 @@ func TestVariables_NonNullableScalars_AllowsNonNullableInputsToBeSetToAValueDire
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -924,7 +924,7 @@ func TestVariables_NonNullableScalars_PassesAlongNullForNonNullableInputsIfExpli
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -956,7 +956,7 @@ func TestVariables_ListsAndNullability_AllowsListsToBeNull(t *testing.T) {
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -987,7 +987,7 @@ func TestVariables_ListsAndNullability_AllowsListsToContainValues(t *testing.T) 
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1018,7 +1018,7 @@ func TestVariables_ListsAndNullability_AllowsListsToContainNull(t *testing.T) {
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1079,7 +1079,7 @@ func TestVariables_ListsAndNullability_AllowsNonNullListsToContainValues(t *test
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1109,7 +1109,7 @@ func TestVariables_ListsAndNullability_AllowsNonNullListsToContainNull(t *testin
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1139,7 +1139,7 @@ func TestVariables_ListsAndNullability_AllowsListsOfNonNullsToBeNull(t *testing.
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1169,7 +1169,7 @@ func TestVariables_ListsAndNullability_AllowsListsOfNonNullsToContainValues(t *t
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1271,7 +1271,7 @@ func TestVariables_ListsAndNullability_AllowsNonNullListsOfNonNulsToContainValue
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1410,7 +1410,7 @@ func TestVariables_UsesArgumentDefaultValues_WhenNoArgumentProvided(t *testing.T
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1436,7 +1436,7 @@ func TestVariables_UsesArgumentDefaultValues_WhenNullableVariableProvided(t *tes
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1462,7 +1462,7 @@ func TestVariables_UsesArgumentDefaultValues_WhenArgumentProvidedCannotBeParsed(
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }

--- a/variables_test.go
+++ b/variables_test.go
@@ -14,19 +14,19 @@ import (
 
 var testComplexScalar *graphql.Scalar = graphql.NewScalar(graphql.ScalarConfig{
 	Name: "ComplexScalar",
-	Serialize: func(value interface{}) interface{} {
+	Serialize: func(value any) any {
 		if value == "DeserializedValue" {
 			return "SerializedValue"
 		}
 		return nil
 	},
-	ParseValue: func(value interface{}) interface{} {
+	ParseValue: func(value any) any {
 		if value == "SerializedValue" {
 			return "DeserializedValue"
 		}
 		return nil
 	},
-	ParseLiteral: func(valueAST ast.Value) interface{} {
+	ParseLiteral: func(valueAST ast.Value) any {
 		astValue := valueAST.GetValue()
 		if astValue, ok := astValue.(string); ok && astValue == "SerializedValue" {
 			return "DeserializedValue"
@@ -65,7 +65,7 @@ var testNestedInputObject *graphql.InputObject = graphql.NewInputObject(graphql.
 	},
 })
 
-func inputResolved(p graphql.ResolveParams) (interface{}, error) {
+func inputResolved(p graphql.ResolveParams) (any, error) {
 	input, ok := p.Args["input"]
 	if !ok {
 		return nil, nil
@@ -177,7 +177,7 @@ func TestVariables_ObjectsAndNullability_UsingInlineStructs_ExecutesWithComplexI
         }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithObjectInput": `{"a":"foo","b":["bar"],"c":"baz"}`,
 		},
 	}
@@ -204,7 +204,7 @@ func TestVariables_ObjectsAndNullability_UsingInlineStructs_ProperlyParsesSingle
         }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithObjectInput": `{"a":"foo","b":["bar"],"c":"baz"}`,
 		},
 	}
@@ -231,7 +231,7 @@ func TestVariables_ObjectsAndNullability_UsingInlineStructs_DoesNotUseIncorrectV
         }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithObjectInput": nil,
 		},
 	}
@@ -258,7 +258,7 @@ func TestVariables_ObjectsAndNullability_UsingInlineStructs_ProperlyRunsParseLit
         }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithObjectInput": `{"a":"foo","d":"DeserializedValue"}`,
 		},
 	}
@@ -289,15 +289,15 @@ func testVariables_ObjectsAndNullability_UsingVariables_GetAST(t *testing.T) *as
 }
 func TestVariables_ObjectsAndNullability_UsingVariables_ExecutesWithComplexInput(t *testing.T) {
 
-	params := map[string]interface{}{
-		"input": map[string]interface{}{
+	params := map[string]any{
+		"input": map[string]any{
 			"a": "foo",
-			"b": []interface{}{"bar"},
+			"b": []any{"bar"},
 			"c": "baz",
 		},
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithObjectInput": `{"a":"foo","b":["bar"],"c":"baz"}`,
 		},
 	}
@@ -327,7 +327,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_UsesDefaultValueWhenNotP
 	  }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithObjectInput": `{"a":"foo","b":["bar"],"c":"baz"}`,
 		},
 	}
@@ -348,15 +348,15 @@ func TestVariables_ObjectsAndNullability_UsingVariables_UsesDefaultValueWhenNotP
 	}
 }
 func TestVariables_ObjectsAndNullability_UsingVariables_ProperlyParsesSingleValueToList(t *testing.T) {
-	params := map[string]interface{}{
-		"input": map[string]interface{}{
+	params := map[string]any{
+		"input": map[string]any{
 			"a": "foo",
 			"b": "bar",
 			"c": "baz",
 		},
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithObjectInput": `{"a":"foo","b":["bar"],"c":"baz"}`,
 		},
 	}
@@ -378,14 +378,14 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ProperlyParsesSingleValu
 	}
 }
 func TestVariables_ObjectsAndNullability_UsingVariables_ExecutesWithComplexScalarInput(t *testing.T) {
-	params := map[string]interface{}{
-		"input": map[string]interface{}{
+	params := map[string]any{
+		"input": map[string]any{
 			"c": "foo",
 			"d": "SerializedValue",
 		},
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithObjectInput": `{"c":"foo","d":"DeserializedValue"}`,
 		},
 	}
@@ -407,8 +407,8 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ExecutesWithComplexScala
 	}
 }
 func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnNullForNestedNonNull(t *testing.T) {
-	params := map[string]interface{}{
-		"input": map[string]interface{}{
+	params := map[string]any{
+		"input": map[string]any{
 			"a": "foo",
 			"b": "bar",
 			"c": nil,
@@ -443,7 +443,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnNullForNestedNon
 	}
 }
 func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnIncorrectType(t *testing.T) {
-	params := map[string]interface{}{
+	params := map[string]any{
 		"input": "foo bar",
 	}
 	expected := &graphql.Result{
@@ -474,8 +474,8 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnIncorrectType(t 
 	}
 }
 func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnOmissionOfNestedNonNull(t *testing.T) {
-	params := map[string]interface{}{
-		"input": map[string]interface{}{
+	params := map[string]any{
+		"input": map[string]any{
 			"a": "foo",
 			"b": "bar",
 		},
@@ -509,9 +509,9 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnOmissionOfNested
 	}
 }
 func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnDeepNestedErrorsAndWithManyErrors(t *testing.T) {
-	params := map[string]interface{}{
-		"input": map[string]interface{}{
-			"na": map[string]interface{}{
+	params := map[string]any{
+		"input": map[string]any{
+			"na": map[string]any{
 				"a": "foo",
 			},
 		},
@@ -551,8 +551,8 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnDeepNestedErrors
 	}
 }
 func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnAdditionOfUnknownInputField(t *testing.T) {
-	params := map[string]interface{}{
-		"input": map[string]interface{}{
+	params := map[string]any{
+		"input": map[string]any{
 			"a":     "foo",
 			"b":     "bar",
 			"c":     "baz",
@@ -595,7 +595,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeOmitted(t *testing.T)
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithNullableStringInput": nil,
 		},
 	}
@@ -622,7 +622,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeOmittedInAVariable(t 
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithNullableStringInput": nil,
 		},
 	}
@@ -649,7 +649,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeOmittedInAnUnlistedVa
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithNullableStringInput": nil,
 		},
 	}
@@ -675,11 +675,11 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeSetToNullInAVariable(
         fieldWithNullableStringInput(input: $value)
       }
 	`
-	params := map[string]interface{}{
+	params := map[string]any{
 		"value": nil,
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithNullableStringInput": nil,
 		},
 	}
@@ -706,11 +706,11 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeSetToAValueInAVariabl
         fieldWithNullableStringInput(input: $value)
       }
 	`
-	params := map[string]interface{}{
+	params := map[string]any{
 		"value": "a",
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithNullableStringInput": `"a"`,
 		},
 	}
@@ -738,7 +738,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeSetToAValueDirectly(t
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithNullableStringInput": `"a"`,
 		},
 	}
@@ -800,7 +800,7 @@ func TestVariables_NonNullableScalars_DoesNotAllowNonNullableInputsToBeSetToNull
         }
 	`
 
-	params := map[string]interface{}{
+	params := map[string]any{
 		"value": nil,
 	}
 	expected := &graphql.Result{
@@ -837,11 +837,11 @@ func TestVariables_NonNullableScalars_AllowsNonNullableInputsToBeSetToAValueInAV
         }
 	`
 
-	params := map[string]interface{}{
+	params := map[string]any{
 		"value": "a",
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithNonNullableStringInput": `"a"`,
 		},
 	}
@@ -869,12 +869,12 @@ func TestVariables_NonNullableScalars_AllowsNonNullableInputsToBeSetToAValueDire
       }
 	`
 
-	params := map[string]interface{}{
+	params := map[string]any{
 		"value": "a",
 	}
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithNonNullableStringInput": `"a"`,
 		},
 	}
@@ -902,12 +902,12 @@ func TestVariables_NonNullableScalars_PassesAlongNullForNonNullableInputsIfExpli
       }
 	`
 
-	params := map[string]interface{}{
+	params := map[string]any{
 		"value": "a",
 	}
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithNonNullableStringInput": nil,
 		},
 	}
@@ -935,12 +935,12 @@ func TestVariables_ListsAndNullability_AllowsListsToBeNull(t *testing.T) {
           list(input: $input)
         }
 	`
-	params := map[string]interface{}{
+	params := map[string]any{
 		"input": nil,
 	}
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"list": nil,
 		},
 	}
@@ -966,12 +966,12 @@ func TestVariables_ListsAndNullability_AllowsListsToContainValues(t *testing.T) 
           list(input: $input)
         }
 	`
-	params := map[string]interface{}{
-		"input": []interface{}{"A"},
+	params := map[string]any{
+		"input": []any{"A"},
 	}
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"list": `["A"]`,
 		},
 	}
@@ -997,12 +997,12 @@ func TestVariables_ListsAndNullability_AllowsListsToContainNull(t *testing.T) {
           list(input: $input)
         }
 	`
-	params := map[string]interface{}{
-		"input": []interface{}{"A", nil, "B"},
+	params := map[string]any{
+		"input": []any{"A", nil, "B"},
 	}
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"list": `["A",null,"B"]`,
 		},
 	}
@@ -1059,11 +1059,11 @@ func TestVariables_ListsAndNullability_AllowsNonNullListsToContainValues(t *test
           nnList(input: $input)
         }
 	`
-	params := map[string]interface{}{
-		"input": []interface{}{"A"},
+	params := map[string]any{
+		"input": []any{"A"},
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"nnList": `["A"]`,
 		},
 	}
@@ -1089,11 +1089,11 @@ func TestVariables_ListsAndNullability_AllowsNonNullListsToContainNull(t *testin
           nnList(input: $input)
         }
 	`
-	params := map[string]interface{}{
-		"input": []interface{}{"A", nil, "B"},
+	params := map[string]any{
+		"input": []any{"A", nil, "B"},
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"nnList": `["A",null,"B"]`,
 		},
 	}
@@ -1119,11 +1119,11 @@ func TestVariables_ListsAndNullability_AllowsListsOfNonNullsToBeNull(t *testing.
           listNN(input: $input)
         }
 	`
-	params := map[string]interface{}{
+	params := map[string]any{
 		"input": nil,
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"listNN": nil,
 		},
 	}
@@ -1149,11 +1149,11 @@ func TestVariables_ListsAndNullability_AllowsListsOfNonNullsToContainValues(t *t
           listNN(input: $input)
         }
 	`
-	params := map[string]interface{}{
-		"input": []interface{}{"A"},
+	params := map[string]any{
+		"input": []any{"A"},
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"listNN": `["A"]`,
 		},
 	}
@@ -1179,8 +1179,8 @@ func TestVariables_ListsAndNullability_DoesNotAllowListOfNonNullsToContainNull(t
           listNN(input: $input)
         }
 	`
-	params := map[string]interface{}{
-		"input": []interface{}{"A", nil, "B"},
+	params := map[string]any{
+		"input": []any{"A", nil, "B"},
 	}
 	expected := &graphql.Result{
 		Data: nil,
@@ -1216,7 +1216,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowNonNullListOfNonNullsToBeNull
           nnListNN(input: $input)
         }
 	`
-	params := map[string]interface{}{
+	params := map[string]any{
 		"input": nil,
 	}
 	expected := &graphql.Result{
@@ -1251,11 +1251,11 @@ func TestVariables_ListsAndNullability_AllowsNonNullListsOfNonNulsToContainValue
           nnListNN(input: $input)
         }
 	`
-	params := map[string]interface{}{
-		"input": []interface{}{"A"},
+	params := map[string]any{
+		"input": []any{"A"},
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"nnListNN": `["A"]`,
 		},
 	}
@@ -1281,8 +1281,8 @@ func TestVariables_ListsAndNullability_DoesNotAllowNonNullListOfNonNullsToContai
           nnListNN(input: $input)
         }
 	`
-	params := map[string]interface{}{
-		"input": []interface{}{"A", nil, "B"},
+	params := map[string]any{
+		"input": []any{"A", nil, "B"},
 	}
 	expected := &graphql.Result{
 		Data: nil,
@@ -1318,9 +1318,9 @@ func TestVariables_ListsAndNullability_DoesNotAllowInvalidTypesToBeUsedAsValues(
           fieldWithObjectInput(input: $input)
         }
 	`
-	params := map[string]interface{}{
-		"input": map[string]interface{}{
-			"list": []interface{}{"A", "B"},
+	params := map[string]any{
+		"input": map[string]any{
+			"list": []any{"A", "B"},
 		},
 	}
 	expected := &graphql.Result{
@@ -1358,7 +1358,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowUnknownTypesToBeUsedAsValues(
           fieldWithObjectInput(input: $input)
         }
 	`
-	params := map[string]interface{}{
+	params := map[string]any{
 		"input": "whoknows",
 	}
 	expected := &graphql.Result{
@@ -1395,7 +1395,7 @@ func TestVariables_UsesArgumentDefaultValues_WhenNoArgumentProvided(t *testing.T
     }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithDefaultArgumentValue": `"Hello World"`,
 		},
 	}
@@ -1421,7 +1421,7 @@ func TestVariables_UsesArgumentDefaultValues_WhenNullableVariableProvided(t *tes
     }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithDefaultArgumentValue": `"Hello World"`,
 		},
 	}
@@ -1447,7 +1447,7 @@ func TestVariables_UsesArgumentDefaultValues_WhenArgumentProvidedCannotBeParsed(
 	}
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"fieldWithDefaultArgumentValue": `"Hello World"`,
 		},
 	}


### PR DESCRIPTION
# Description
- Bumps the minimum go version to `1.23`
- Replaces all use of `interface{}` with `any`
- Resolves most of the warnings generated by both staticcheck and gopls analysers

## Issues addressed in this pull request
- Resolves machship/v3-issues#2720

# Acceptance criteria
- the minimum go version is `1.23`
- `any` is used in place of `interface{}`
- warnings have been resolved
- all tests are passing, as before
