### PR TITLE
Omit non standard introspection types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # GraphQL
 This library is a fork of [graphql-go/graphql](https://github.com/graphql-go/graphql), and implements features outside of latest GraphQL [draft specification](https://spec.graphql.org/draft/). These non-standard features may break tooling when running introspection queries against applications using this library.
 
-The only non-standard feature currently implemented is the concept of Applied Directives. It is implemented by following the [proposal specification](https://graphql-dotnet.github.io/docs/getting-started/directives/#directives-and-introspection). This feature is also implemented by [graphql-dotnet](https://github.com/graphql-dotnet/graphql-dotnet) and [graphql-java](https://github.com/graphql-java/graphql-java) libraries.
+The only non-standard feature currently implemented is the concept of Applied Directives. It is implemented by following the [proposal specification](https://graphql-dotnet.github.io/docs/getting-started/directives/#directives-and-introspection). This feature is also implemented by [graphql-dotnet](https://github.com/graphql-dotnet/graphql-dotnet) and [graphql-java](https://github.com/graphql-java/graphql-java) libraries. More information on the proposal Applied Directive specification is available [here](https://graphql-dotnet.github.io/docs/getting-started/directives/#directives-and-introspection).
 
-There is no way to disable the non-standard features at runtime (unlike the previously mentioned libraries). Therefore, this library should not be used for ordinary GraphQL applications unless you know what you're doing. More information on the proposal Applied Directive specification is available [here](https://graphql-dotnet.github.io/docs/getting-started/directives/#directives-and-introspection).
+By default, the non-standard features are not returned during introspection and therefore _should_ not break tooling, however this cannot be guaranteed. At the very least it does not break [Altair](https://altairgraphql.dev/). In order to observe non-standard types during introspection, execute a query resembling:
+```graphql
+query CustomIntrospection {
+    __schema(includeNonStandard: true) {
+        types {
+            name
+        }
+    }
+}
+```

--- a/examples/star-wars/main.go
+++ b/examples/star-wars/main.go
@@ -6,14 +6,14 @@ import (
 	"net/http"
 
 	"github.com/machship/graphql"
-	"github.com/machship/graphql/testutil"
+	"github.com/machship/graphql/testutil/starwars"
 )
 
 func main() {
 	http.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
 		query := r.URL.Query().Get("query")
 		result := graphql.Do(graphql.Params{
-			Schema:        testutil.StarWarsSchema,
+			Schema:        starwars.Schema,
 			RequestString: query,
 		})
 		json.NewEncoder(w).Encode(result)

--- a/executor.go
+++ b/executor.go
@@ -187,7 +187,6 @@ func executeOperation(p executeOperationParams) *Result {
 		return executeFieldsSerially(executeFieldsParams)
 	}
 	return executeFields(executeFieldsParams)
-
 }
 
 // Extracts the root type of the operation from the schema.
@@ -397,7 +396,7 @@ func dethunkListDepthFirst(list []any) {
 
 type collectFieldsParams struct {
 	ExeContext           *executionContext
-	RuntimeType          *Object // previously known as OperationType
+	RuntimeType          *Object
 	SelectionSet         *ast.SelectionSet
 	Fields               map[string][]*ast.Field
 	VisitedFragmentNames map[string]bool

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/machship/graphql"
 	"github.com/machship/graphql/testutil"
+	"github.com/machship/graphql/testutil/starwars"
 )
 
 type T struct {
@@ -29,7 +30,7 @@ func init() {
 					}
 				}
 			`,
-			Schema: testutil.StarWarsSchema,
+			Schema: starwars.Schema,
 			Expected: &graphql.Result{
 				Data: map[string]any{
 					"hero": map[string]any{
@@ -51,7 +52,7 @@ func init() {
 					}
 				}
 			`,
-			Schema: testutil.StarWarsSchema,
+			Schema: starwars.Schema,
 			Expected: &graphql.Result{
 				Data: map[string]any{
 					"hero": map[string]any{
@@ -80,7 +81,7 @@ func init() {
 					}
 				}
 			`,
-			Schema: testutil.StarWarsSchema,
+			Schema: starwars.Schema,
 			Expected: &graphql.Result{
 				Data: map[string]any{
 					"human": map[string]any{

--- a/introspection.go
+++ b/introspection.go
@@ -20,6 +20,10 @@ const (
 	TypeKindNonNull     = "NON_NULL"
 )
 
+const (
+	appliedDirectivesField string = "appliedDirectives"
+)
+
 var (
 	// SchemaType is the type definition of __Schema.
 	SchemaType *Object
@@ -296,7 +300,7 @@ func init() {
 			"enumValues":    &Field{},
 			"inputFields":   &Field{},
 			"ofType":        &Field{},
-			"appliedDirectives": {
+			appliedDirectivesField: {
 				Resolve: appliedDirectiveResolver,
 				Type: NewNonNull(
 					NewList(
@@ -349,7 +353,7 @@ func init() {
 					return nil, nil
 				},
 			},
-			"appliedDirectives": {
+			appliedDirectivesField: {
 				Resolve: appliedDirectiveResolver,
 				Type: NewNonNull(
 					NewList(
@@ -405,7 +409,7 @@ func init() {
 					return nil, nil
 				},
 			},
-			"appliedDirectives": {
+			appliedDirectivesField: {
 				Resolve: appliedDirectiveResolver,
 				Type: NewNonNull(
 					NewList(
@@ -500,7 +504,7 @@ func init() {
 					return false, nil
 				},
 			},
-			"appliedDirectives": {
+			appliedDirectivesField: {
 				Resolve: appliedDirectiveResolver,
 				Type: NewNonNull(
 					NewList(
@@ -583,7 +587,7 @@ func init() {
 					return nil, nil
 				},
 			},
-			"appliedDirectives": {
+			appliedDirectivesField: {
 				Resolve: func(p ResolveParams) (any, error) {
 					// TODO: figure out why `Schema` is not being passed as a pointer
 					if schema, ok := p.Source.(Schema); ok {
@@ -634,7 +638,7 @@ func init() {
 					return nil, nil
 				},
 			},
-			"appliedDirectives": {
+			appliedDirectivesField: {
 				Resolve: appliedDirectiveResolver,
 				Type: NewNonNull(
 					NewList(

--- a/testutil/starwars/starwars.go
+++ b/testutil/starwars/starwars.go
@@ -1,4 +1,4 @@
-package testutil
+package starwars
 
 import (
 	"strconv"
@@ -7,16 +7,16 @@ import (
 )
 
 var (
-	Luke           StarWarsChar
-	Vader          StarWarsChar
-	Han            StarWarsChar
-	Leia           StarWarsChar
-	Tarkin         StarWarsChar
-	Threepio       StarWarsChar
-	Artoo          StarWarsChar
-	HumanData      map[int]StarWarsChar
-	DroidData      map[int]StarWarsChar
-	StarWarsSchema graphql.Schema
+	Luke      StarWarsChar
+	Vader     StarWarsChar
+	Han       StarWarsChar
+	Leia      StarWarsChar
+	Tarkin    StarWarsChar
+	Threepio  StarWarsChar
+	Artoo     StarWarsChar
+	HumanData map[int]StarWarsChar
+	DroidData map[int]StarWarsChar
+	Schema    graphql.Schema
 
 	humanType *graphql.Object
 	droidType *graphql.Object
@@ -308,9 +308,14 @@ func init() {
 			},
 		},
 	})
-	StarWarsSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
+	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: queryType,
 	})
+	if err != nil {
+		panic(err)
+	}
+
+	Schema = schema
 }
 
 func GetHuman(id int) StarWarsChar {


### PR DESCRIPTION
# Description
- Moves the star wars schema definition to its own package for the purpose of local testing with binaries and altair
- Implements an optional argument (`includeNonStandard`) on the `__schema` type when introspecting
  - Set it to `true` in order to receive non-standard types (currently only `__AppliedDirective` and `__DirectiveArgument`)
  - Either omit it or set it to `false` in order to receive the types that are only within the graphql specification
- Supports the ability to toggle between receiving non-standard types and not on a per-request basis.

## Issues addressed in this pull request
- Resolves machship/inquisitor#124
- Resolves machship/inquisitor#125

# Acceptance criteria
- Non-standard fields and types are omitted from introspection by default
- Tooling will no longer throw errors or warnings about non-standard types being returned to a standard introspection query
